### PR TITLE
Implemented Output Directory Selection, Adjusted GUI Layout 

### DIFF
--- a/BeyondChaos/bcex.cfg
+++ b/BeyondChaos/bcex.cfg
@@ -1,5 +1,6 @@
 [ROM]
-path = C:/Users/Michael/Documents/GitHub/crimdahl/BeyondChaosRandomizer/BeyondChaos/dist/Final Fantasy III (U) (V1.0) [!].smc
+path = D:/BizHawk-2.4/Roms/Final Fantasy III (U) (V1.0) [!].smc
+output = 
 
 [speeddial]
 

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -4441,7 +4441,7 @@ def randomize(args: List[str]) -> str:
             while True:
                 #Input loop to make sure we get a valid directory
                 previous_output = f" (blank for previous: {previous_output_directory})"
-                output_directory = input(f"Please input the directory to place randomized the ROM file. {previous_output}:\n> ").strip().replace('\\', '/')
+                output_directory = input(f"Please input the directory to place the randomized ROM file. {previous_output}:\n> ").strip().replace('\\', '/')
                 print()
 
                 if previous_output_directory and not output_directory:


### PR DESCRIPTION
Users can now select a ROM output directory that is different from the input ROM's directory. Works with both GUI and console and remembers your selection by logging the choice in bcex.cfg. Auto-detects invalid directories before attempting randomization.

GUI-specific Changes:
-Adjusted the top portion of the GUI to use a QGridLayout object instead of a TopHBox object. This should make it easier to make additional adjustments to the GUI in the future.
-Added Output Directory field and browse button.
-Aligned ROM field, Output Directory field, and Seed fields vertically.