### PR TITLE
adjust 8a814ae to not break on some user-entered paths

### DIFF
--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -4426,6 +4426,10 @@ def randomize(args: List[str]) -> str:
     if previous_rom_path and not sourcefile:
         sourcefile = previous_rom_path
         
+    # Correct for Windows paths given with surrounding quotes
+    # (e.g. drag & drop onto console when path includes a space)
+    if sourcefile.startswith('"') and sourcefile.endswith('"'):
+        sourcefile = sourcefile.strip('"')
     sourcefile = os.path.abspath(sourcefile)
     
     try:
@@ -4449,7 +4453,9 @@ def randomize(args: List[str]) -> str:
 
                 if previous_output_directory and not output_directory:
                     output_directory = previous_output_directory
-
+                if output_directory.startswith('"') and output_directory.endswith('"'):
+                    output_directory = output_directory.strip('"')
+                    
                 if os.path.isdir(output_directory):
                     #Valid directory received. Break out of the loop.
                     break

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -4425,6 +4425,9 @@ def randomize(args: List[str]) -> str:
         
     if previous_rom_path and not sourcefile:
         sourcefile = previous_rom_path
+        
+    sourcefile = os.path.abspath(sourcefile)
+    
     try:
         f = open(sourcefile, 'rb')
         data = f.read()
@@ -4436,7 +4439,7 @@ def randomize(args: List[str]) -> str:
         else:
             #If no previous directory or an invalid directory was obtained from bcex.cfg, default to the ROM's directory
             if not previous_output_directory or not os.path.isdir(previous_output_directory):
-                previous_output_directory = sourcefile[:sourcefile.rindex('/')]
+                previous_output_directory = os.path.dirname(sourcefile)
 
             while True:
                 #Input loop to make sure we get a valid directory
@@ -4584,13 +4587,17 @@ def randomize(args: List[str]) -> str:
     original_rom_location = sourcefile
 
     if '.' in sourcefile:
-        tempname = sourcefile.rsplit('.', 1)
+        tempname = os.path.basename(sourcefile).rsplit('.', 1)
     else:
-        tempname = [sourcefile, 'smc']
+        tempname = [os.path.basename(sourcefile), 'smc']
     
-    outfile = output_directory + '.'.join([tempname[0][tempname[0].rindex('/'):], str(seed), tempname[1]])
-    outlog = output_directory + '.'.join([tempname[0][tempname[0].rindex('/'):], str(seed), 'txt'])
-
+    outfile = os.path.join(output_directory,
+                           '.'.join([os.path.basename(tempname[0]),
+                                     str(seed), tempname[1]]))
+    outlog = os.path.join(output_directory,
+                          '.'.join([os.path.basename(tempname[0]),
+                                    str(seed), 'txt']))
+                                     
     if saveflags:
         try:
             config = configparser.ConfigParser()


### PR DESCRIPTION
fixing issues or possible issues with paths such as:
`ff6.smc`
`d:\roms\ff6.smc`
`/home/some.person/roms/final_fantasy_6`
`"C:\Users\Human\Desktop\New folder (6)\ff6.smc"`