### PR TITLE
Bug Fixes. Switches randomizer.randomize() from args to kwargs. Implements spinboxes as an option for codes.

### DIFF
--- a/BeyondChaos/bcex.cfg
+++ b/BeyondChaos/bcex.cfg
@@ -1,6 +1,6 @@
 [ROM]
-path = D:/BizHawk-2.4/Roms/Final Fantasy III (U) (V1.0) [!].smc
-output = C:/Users/Michael/Documents/GitHub/crimdahl/BeyondChaosRandomizer/BeyondChaos
+path = C:\Users\Michael\Documents\GitHub\crimdahl\BeyondChaosRandomizer\Final Fantasy III (U) (V1.0) [!].smc
+output = .\dist
 
 [speeddial]
 

--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -12,7 +12,7 @@ from PyQt5.QtGui import QCursor
 from PyQt5.QtWidgets import (QPushButton, QCheckBox, QWidget, QVBoxLayout, 
     QLabel, QGroupBox, QHBoxLayout, QLineEdit, QComboBox, QFileDialog, 
     QApplication, QTabWidget, QInputDialog, QScrollArea, QMessageBox, 
-    QGraphicsDropShadowEffect, QGridLayout, QSpinBox)
+    QGraphicsDropShadowEffect, QGridLayout, QSpinBox, QDoubleSpinBox)
 
 #Local application imports
 from config import (readFlags, writeFlags)
@@ -50,7 +50,6 @@ class FlagCheckBox(QCheckBox):
         self.setText(text)
         self.value = value
 
-
 class Window(QWidget):
 
     def __init__(self):
@@ -70,6 +69,10 @@ class Window(QWidget):
         self.mode = "normal"
         self.seed = ""
         self.flags = []
+        self.expMultiplier = 1
+        self.gpMultiplier = 1
+        self.mpMultiplier = 1
+        self.randomboost = 1
 
 
         # dictionaries to hold flag data
@@ -253,13 +256,12 @@ class Window(QWidget):
         gridLayout.addWidget(lblRomOutput, 2, 1)
 
         self.romOutput = QLineEdit()
-
         self.romInput.textChanged[str].connect(self.updateRomOutputPlaceholder)
         gridLayout.addWidget(self.romOutput, 2, 2, 1, 3)
 
         btnRomOutput = QPushButton("Browse")
         btnRomOutput.setMaximumWidth(self.width)
-        btnRomOutput.setMaximumHeight(self.height)        
+        btnRomOutput.setMaximumHeight(self.height)
         btnRomOutput.setStyleSheet(
             "font:bold;"
             "font-size:18px;"
@@ -457,15 +459,40 @@ class Window(QWidget):
                                self.tabNames):
             tabObj = QScrollArea()
             tabs.addTab(tabObj, names)
-            tablayout = QVBoxLayout()
+            tablayout = QGridLayout()
+            currentRow = 0
             for flagname, flagdesc in d.items():
-                cbox = FlagCheckBox(
-                    f"{flagname}  -  {flagdesc['explanation']}", 
-                    flagname
-                )
-                self.checkBoxes.append(cbox)
-                tablayout.addWidget(cbox)
-                cbox.clicked.connect(lambda checked: self.flagButtonClicked())
+                if flagdesc['inputtype'] == 'checkbox':
+                    cbox = FlagCheckBox(
+                        f"{flagname}  -  {flagdesc['explanation']}", 
+                        flagname
+                    )
+                    self.checkBoxes.append(cbox)
+                    tablayout.addWidget(cbox, currentRow, 1, 1, 2)
+                    cbox.clicked.connect(lambda checked: self.flagButtonClicked())
+                elif  flagdesc['inputtype'] == 'numberbox':
+                    if flagname in ['exp','gp', 'mps']:
+                        nbox = QDoubleSpinBox()
+                    else:
+                        nbox = QSpinBox()
+                    nbox.setSpecialValueText('Off')
+                    nbox.setFixedWidth(50)
+                    nbox.setMinimum(-1)
+                    nbox.setValue(nbox.minimum())
+                    nbox.setMaximum(50)
+                    if flagname in ['exp','gp', 'mps']:
+                        nbox.setFixedWidth(70)
+                        nbox.setMinimum(-0.1)
+                        nbox.setValue(-0.1)
+                        nbox.setSingleStep(.1)
+                        nbox.setSuffix("x")
+                    nbox.text = flagname
+                    flaglbl = QLabel(f"{flagname}  -  {flagdesc['explanation']}")
+                    tablayout.addWidget(nbox, currentRow, 1)
+                    tablayout.addWidget(flaglbl, currentRow, 2)
+                    nbox.valueChanged.connect(lambda: self.flagButtonClicked())
+                currentRow += 1
+
             t.setLayout(tablayout)
             tabObj.setWidgetResizable(True)
             tabObj.setWidget(t)
@@ -691,12 +718,14 @@ class Window(QWidget):
 
             d[code.name] = {
                 'explanation': code.long_description, 
+                'inputtype': code.inputtype,
                 'checked': False
             }
 
         for flag in sorted(ALL_FLAGS):
             self.flag[flag.name] = {
                 'explanation': flag.description, 
+                'inputtype': flag.inputtype,
                 'checked': True
             }
 
@@ -847,8 +876,28 @@ class Window(QWidget):
                         self.flags.append(c.value)
                 else:
                     d[c.value]['checked'] = False
+            children = t.findChildren(QSpinBox) + t.findChildren(QDoubleSpinBox)
+            for c in children:
+                if c.text == 'exp':
+                    self.expMultiplier = c.value()
+                elif c.text == 'gp':
+                    self.gpMultiplier = c.value()
+                elif c.text == 'mps':
+                    self.mpMultiplier = c.value()
+                elif c.text == 'randomboost':
+                    self.randomboost = c.value()
+                if not c.value() == c.minimum():
+                    flagset = False
+                    for flag in self.flags:
+                        if flag == c.text:
+                            flagset = True
+                    if flagset == False:
+                        self.flags.append(c.text)
+
+            
         self.updateFlagString()
 
+            
 
     # Opens file dialog to select rom file and assigns it to value in
     # parent/Window class
@@ -1047,14 +1096,23 @@ class Window(QWidget):
                     QtCore.pyqtRemoveInputHook()
                     # TODO: put this in a new thread
                     try:
+                        #resultFile = randomizer.randomize(
+                        #    args=[
+                        #        'beyondchaos.py', 
+                        #        self.romText, 
+                        #        bundle, 
+                        #        "test", 
+                        #        self.romOutputDirectory
+                        #    ]
+                        #)
                         resultFile = randomizer.randomize(
-                            args=[
-                                'beyondchaos.py', 
-                                self.romText, 
-                                bundle, 
-                                "test", 
-                                self.romOutputDirectory
-                            ]
+                            sourcefile=self.romText,
+                            seed=bundle,
+                            output_directory=self.romOutputDirectory,
+                            expMultiplier=self.expMultiplier,
+                            gpMultiplier=self.gpMultiplier,
+                            mpMultiplier=self.mpMultiplier,
+                            randomboost=self.randomboost
                         )
                         if self.seed:
                             self.seed = str(int(self.seed) + 1)

--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -1143,7 +1143,7 @@ class Window(QWidget):
 
     def updateRomOutputPlaceholder(self, value):
         try:
-            self.romOutput.setPlaceholderText(value[:str(value).rindex('/')])
+            self.romOutput.setPlaceholderText(os.path.dirname(value))
         except ValueError:
             pass
 

--- a/BeyondChaos/formationrandomizer.py
+++ b/BeyondChaos/formationrandomizer.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 import monsterrandomizer
 from options import Options_
-from math import log
+from math import log, floor
 
 from monsterrandomizer import monsterdict, get_monsters
 from utils import read_multi, write_multi, utilrandom as random
@@ -247,7 +247,7 @@ class Formation():
 
         if self.ap is not None:
             fout.seek(0x1fb400 + self.formid)
-            fout.write(bytes([self.ap]))
+            fout.write(bytes([min(self.ap, 256)]))
 
     def lookup_enemies(self):
         self.enemies = []
@@ -326,15 +326,15 @@ class Formation():
     def exp(self):
         return sum(e.stats['xp'] for e in self.present_enemies)
 
-    def mutate(self, ap=False):
+    def mutate(self, ap=False, apMultiplier=None):
         if ap and self.ap is not None and 0 < self.ap < 100:
             factor = self.levelrank() / 100
             self.ap += int(round(self.ap * factor))
             while random.choice([True, False]):
                 self.ap += random.randint(-1, 1)
                 self.ap = min(100, max(self.ap, 0))
-            if Options_.is_code_active("mps"):
-                self.ap = self.ap * 3
+            if apMultiplier:
+                self.ap = floor(self.ap * apMultiplier)
         if self.ambusher:
             if not (self.pincer_prohibited and self.back_prohibited):
                 self.misc1 |= 0x90

--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -15,6 +15,7 @@ class Flag:
     name: str
     attr: str
     description: str
+    inputtype: str
 
     def __post_init__(self):
         object.__setattr__(self, 'name', self.name[0])
@@ -26,6 +27,7 @@ class Code:
     description: str
     long_description: str
     category: str
+    inputtype: str
     key1: str = ''
     key2: str = ''
 
@@ -194,135 +196,135 @@ ALL_MODES = [
 ]
 
 ALL_FLAGS = [
-    Flag('b', 'fix_exploits', 'Make the game more balanced by removing known exploits.'),
-    Flag('c', 'random_palettes_and_names', 'Randomize palettes and names of various things.'),
-    Flag('d', 'random_final_dungeon', 'Randomize final dungeon.'),
-    Flag('e', 'random_espers', 'Randomize esper spells and levelup bonuses.'),
-    Flag('f', 'random_formations', 'Randomize enemy formations.'),
-    Flag('g', 'random_dances', 'Randomize dances'),
-    Flag('i', 'random_items', 'Randomize the stats of equippable items.'),
-    Flag('j', 'randomize_forest', 'Randomize the phantom forest.'),
-    Flag('k', 'random_clock', 'Randomize the clock in Zozo'),
-    Flag('l', 'random_blitz', 'Randomize blitz inputs.'),
-    Flag('m', 'random_enemy_stats', 'Randomize enemy stats.'),
-    Flag('n', 'random_window', 'Randomize window background colors.'),
-    Flag('o', 'shuffle_commands', "Shuffle characters' in-battle commands"),
-    Flag('p', 'random_animation_palettes', 'Randomize the palettes of spells and weapon animations.'),
-    Flag('q', 'random_character_stats', 'Randomize what equipment each character can wear and character stats.'),
-    Flag('r', 'shuffle_wor', 'Randomize character locations in the world of ruin.'),
-    Flag('s', 'swap_sprites', 'Swap character graphics around.'),
-    Flag('t', 'random_treasure', 'Randomize treasure, including chests, colosseum, shops, and enemy drops.'),
-    Flag('u', 'random_zerker', 'Umaro risk. (Random character will be berserk)'),
-    Flag('w', 'replace_commands', 'Generate new commands for characters, replacing old commands.'),
-    Flag('y', 'randomize_magicite', 'Shuffle magicite locations.'),
-    Flag('z', 'sprint', 'Always have "Sprint Shoes" effect.'),
+    Flag('b', 'fix_exploits', 'Make the game more balanced by removing known exploits.', "checkbox"),
+    Flag('c', 'random_palettes_and_names', 'Randomize palettes and names of various things.', "checkbox"),
+    Flag('d', 'random_final_dungeon', 'Randomize final dungeon.', "checkbox"),
+    Flag('e', 'random_espers', 'Randomize esper spells and levelup bonuses.', "checkbox"),
+    Flag('f', 'random_formations', 'Randomize enemy formations.', "checkbox"),
+    Flag('g', 'random_dances', 'Randomize dances', "checkbox"),
+    Flag('i', 'random_items', 'Randomize the stats of equippable items.', "checkbox"),
+    Flag('j', 'randomize_forest', 'Randomize the phantom forest.', "checkbox"),
+    Flag('k', 'random_clock', 'Randomize the clock in Zozo', "checkbox"),
+    Flag('l', 'random_blitz', 'Randomize blitz inputs.', "checkbox"),
+    Flag('m', 'random_enemy_stats', 'Randomize enemy stats.', "checkbox"),
+    Flag('n', 'random_window', 'Randomize window background colors.', "checkbox"),
+    Flag('o', 'shuffle_commands', "Shuffle characters' in-battle commands", "checkbox"),
+    Flag('p', 'random_animation_palettes', 'Randomize the palettes of spells and weapon animations.', "checkbox"),
+    Flag('q', 'random_character_stats', 'Randomize what equipment each character can wear and character stats.', "checkbox"),
+    Flag('r', 'shuffle_wor', 'Randomize character locations in the world of ruin.', "checkbox"),
+    Flag('s', 'swap_sprites', 'Swap character graphics around.', "checkbox"),
+    Flag('t', 'random_treasure', 'Randomize treasure, including chests, colosseum, shops, and enemy drops.', "checkbox"),
+    Flag('u', 'random_zerker', 'Umaro risk. (Random character will be berserk)', "checkbox"),
+    Flag('w', 'replace_commands', 'Generate new commands for characters, replacing old commands.', "checkbox"),
+    Flag('y', 'randomize_magicite', 'Shuffle magicite locations.', "checkbox"),
+    Flag('z', 'sprint', 'Always have "Sprint Shoes" effect.', "checkbox"),
 ]
 
 
 NORMAL_CODES = [
     # Sprite codes
-    Code('bravenudeworld', "TINA PARTY MODE", "All characters use the Esper Terra sprite.", "sprite"),
-    Code('makeover', "SPRITE REPLACEMENT MODE", "Some sprites are replaced with new ones (like Cecil or Zero Suit Samus).", "sprite"),
-    Code('kupokupo', "MOOGLE MODE", "All party members are moogles except Mog. With partyparty, all characters are moogles, except Mog, Esper Terra, and Imps.", "sprite"),
-    Code('partyparty', "CRAZY PARTY MODE", "Kefka, Trooper, Banon, Leo, Ghost, Merchant, Esper Terra, and Soldier are mixed into the sprites that can be acquired by playable characters. Those sprites are also randomized themselves, allowing Leo to look like Edgar, for example.", "sprite"),
-    Code('quikdraw', "QUIKDRAW MODE", "All characters look like imperial soldiers, and none of them have Gau's Rage skill.", "sprite"),
+    Code('bravenudeworld', "TINA PARTY MODE", "All characters use the Esper Terra sprite.", "sprite", "checkbox"),
+    Code('makeover', "SPRITE REPLACEMENT MODE", "Some sprites are replaced with new ones (like Cecil or Zero Suit Samus).", "sprite", "checkbox"),
+    Code('kupokupo', "MOOGLE MODE", "All party members are moogles except Mog. With partyparty, all characters are moogles, except Mog, Esper Terra, and Imps.", "sprite", "checkbox"),
+    Code('partyparty', "CRAZY PARTY MODE", "Kefka, Trooper, Banon, Leo, Ghost, Merchant, Esper Terra, and Soldier are mixed into the sprites that can be acquired by playable characters. Those sprites are also randomized themselves, allowing Leo to look like Edgar, for example.", "sprite", "checkbox"),
+    Code('quikdraw', "QUIKDRAW MODE", "All characters look like imperial soldiers, and none of them have Gau's Rage skill.", "sprite", "checkbox"),
     # Aesthetic codes
-    Code('alasdraco', "JAM UP YOUR OPERA MODE", "Randomizes the sprites of Maria, Draco, Ralse, the Impresario, the flowers Maria throws from the balcony, and the weight Ultros drops, as well as the singing voices and the names of the factions.", "aesthetic"),
-    Code('bingoboingo', "BINGO BONUS", "Generates a Bingo table with spells, items, equipment, and enemy squares to check off. Players can set victory requirements like achieving a line, or acquiring a certain number of points. The ROM does not interact with the bingo card.", "aesthetic"),
-    Code('capslockoff', "Mixed Case Names Mode", "Names use whatever capitalization is in the name lists instead of all caps.", "aesthetic"),
-    Code('johnnydmad', "MUSIC REPLACEMENT MODE", "Randomizes music with regard to what would make sense in a given location.", "aesthetic"),
-    Code('johnnyachaotic', "MUSIC MANGLING MODE", "Randomizes music with no regard to what would make sense in a given location.", "aesthetic"),
-    Code('notawaiter', "CUTSCENE SKIPS", "Up to Kefka at Narshe, the vast majority of mandatory cutscenes are completely removed. Optional cutscenes are not removed.", "aesthetic"),
-    Code('fightclub', "MORE LIKE COLI-DON'T-SEE-'EM", "Does not allow you to see the coliseum rewards before betting, but you can often run from the coliseum battles to keep your item.", "aesthetic"),
+    Code('alasdraco', "JAM UP YOUR OPERA MODE", "Randomizes the sprites of Maria, Draco, Ralse, the Impresario, the flowers Maria throws from the balcony, and the weight Ultros drops, as well as the singing voices and the names of the factions.", "aesthetic", "checkbox"),
+    Code('bingoboingo', "BINGO BONUS", "Generates a Bingo table with spells, items, equipment, and enemy squares to check off. Players can set victory requirements like achieving a line, or acquiring a certain number of points. The ROM does not interact with the bingo card.", "aesthetic", "checkbox"),
+    Code('capslockoff', "Mixed Case Names Mode", "Names use whatever capitalization is in the name lists instead of all caps.", "aesthetic", "checkbox"),
+    Code('johnnydmad', "MUSIC REPLACEMENT MODE", "Randomizes music with regard to what would make sense in a given location.", "aesthetic", "checkbox"),
+    Code('johnnyachaotic', "MUSIC MANGLING MODE", "Randomizes music with no regard to what would make sense in a given location.", "aesthetic", "checkbox"),
+    Code('notawaiter', "CUTSCENE SKIPS", "Up to Kefka at Narshe, the vast majority of mandatory cutscenes are completely removed. Optional cutscenes are not removed.", "aesthetic", "checkbox"),
+    Code('fightclub', "MORE LIKE COLI-DON'T-SEE-'EM", "Does not allow you to see the coliseum rewards before betting, but you can often run from the coliseum battles to keep your item.", "aesthetic", "checkbox"),
 
     #battle codes
-    Code('electricboogaloo', "WILD ITEM BREAK MODE", "Increases the list of spells that items can break and proc for. Items can break for potentially any spell, and weapons can potentially proc any spell excluding SwdTechs, Blitzes, Slots, and a couple other skills.", "battle"),
-    Code('collateraldamage', "ITEM BREAK MODE", "All pieces of equipment break for spells. Characters only have the Fight and Item commands, and enemies will use items drastically more often than usual.", "battle"),
-    Code('masseffect', "WILD EQUIPMENT EFFECT MODE", "Increases the number of rogue effects on equipment by a large amount.", "battle"),
-    Code('randombosses', "RANDOM BOSSES MODE", "Causes boss skills to be randomized similarly to regular enemy skills. Boss skills can change to similarly powerful skills.", "battle"),
-    Code('replaceeverything', "REPLACE ALL SKILLS MODE", "All vanilla skills that can be replaced, are replaced.", "battle"),
-    Code('allcombos', "ALL COMBOS MODE", "All skills that get replaced with something are replaced with combo skills.", "battle"),
-    Code('nocombos', "No Ccombo moves", "There will be no combo(dual) skills.", "battle"),
-    Code('endless9', "ENDLESS NINE MODE", "All R-[skills] are automatically changed to 9x[skills]. W-[skills] will become 8x[skills].", "battle"),
-    Code('supernatural', "SUPER NATURAL MAGIC MODE", "Makes it so that any character with the Magic command will have natural magic.", "battle"),
-    Code('canttouchthis', "INVINCIBILITY", "All characters have 255 Defense and 255 Magic Defense, as well as 128 Evasion and Magic Evasion.", "battle"),
-    Code('naturalstats', "NATURAL STATS MODE", "No Espers will grant stat bonuses upon leveling up.", "battle"),
-    Code('exp', "3 Times Exp", "All battles will award 3 times exp", "beta"),
-    Code('gp', "3 Times gp", "All battles will award 3 times gp", "beta"),
-    Code('mps', "3 Times magic points", "All battles will award 3 times magic points", "beta"),
-    Code('dancelessons', "NO DANCE FAILURES", "Removes the 50% chance that dances will fail when used on a different terrain.", "beta"),
+    Code('electricboogaloo', "WILD ITEM BREAK MODE", "Increases the list of spells that items can break and proc for. Items can break for potentially any spell, and weapons can potentially proc any spell excluding SwdTechs, Blitzes, Slots, and a couple other skills.", "battle", "checkbox"),
+    Code('collateraldamage', "ITEM BREAK MODE", "All pieces of equipment break for spells. Characters only have the Fight and Item commands, and enemies will use items drastically more often than usual.", "battle", "checkbox"),
+    Code('masseffect', "WILD EQUIPMENT EFFECT MODE", "Increases the number of rogue effects on equipment by a large amount.", "battle", "checkbox"),
+    Code('randombosses', "RANDOM BOSSES MODE", "Causes boss skills to be randomized similarly to regular enemy skills. Boss skills can change to similarly powerful skills.", "battle", "checkbox"),
+    Code('replaceeverything', "REPLACE ALL SKILLS MODE", "All vanilla skills that can be replaced, are replaced.", "battle", "checkbox"),
+    Code('allcombos', "ALL COMBOS MODE", "All skills that get replaced with something are replaced with combo skills.", "battle", "checkbox"),
+    Code('nocombos', "No Ccombo moves", "There will be no combo(dual) skills.", "battle", "checkbox"),
+    Code('endless9', "ENDLESS NINE MODE", "All R-[skills] are automatically changed to 9x[skills]. W-[skills] will become 8x[skills].", "battle", "checkbox"),
+    Code('supernatural', "SUPER NATURAL MAGIC MODE", "Makes it so that any character with the Magic command will have natural magic.", "battle", "checkbox"),
+    Code('canttouchthis', "INVINCIBILITY", "All characters have 255 Defense and 255 Magic Defense, as well as 128 Evasion and Magic Evasion.", "battle", "checkbox"),
+    Code('naturalstats', "NATURAL STATS MODE", "No Espers will grant stat bonuses upon leveling up.", "battle", "checkbox"),
+    Code('exp', "Multiplied Exp", "All battles will award multiplied exp", "beta", "numberbox"),
+    Code('gp', "multiplied gp", "All battles will award multiplied gp", "beta", "numberbox"),
+    Code('mps', "multiplied magic points", "All battles will award multiplied magic points.", "beta", "numberbox"),
+    Code('dancelessons', "NO DANCE FAILURES", "Removes the 50% chance that dances will fail when used on a different terrain.", "beta", "checkbox"),
 
-    Code('airship', "AIRSHIP MODE", "The party will have access to the airship immediately after leaving Narshe. Chocobo stables can also be used to acquire the airship. Doing events out of order can cause softlocks.", "gamebreaking"),
+    Code('airship', "AIRSHIP MODE", "The party will have access to the airship immediately after leaving Narshe. Chocobo stables can also be used to acquire the airship. Doing events out of order can cause softlocks.", "gamebreaking", "checkbox"),
     
-    Code('bsiab', "UNBALANCED MONSTER CHESTS MODE", "Reverts the monster-in-a-box selection algorithm to be (mostly) the same as versions prior to EX v3.", "major"),
-    Code('llg', "LOW LEVEL GAME MODE", "Stands for Low Level Game. No encounters will yield any Experience Points.", "major"),
-    Code('mimetime', 'ALTERNATE GOGO MODE', "Gogo will be hidden somewhere in the world of ruin disguised as another character. Bring that character to him to recruit him.", "major"),
-    Code('nomiabs', 'NO MIAB MODE', "Chests will never have monster encounters in them", "beta"),
+    Code('bsiab', "UNBALANCED MONSTER CHESTS MODE", "Reverts the monster-in-a-box selection algorithm to be (mostly) the same as versions prior to EX v3.", "major", "checkbox"),
+    #Code('llg', "LOW LEVEL GAME MODE", "Stands for Low Level Game. No encounters will yield any Experience Points.", "major", "checkbox"),
+    Code('mimetime', 'ALTERNATE GOGO MODE', "Gogo will be hidden somewhere in the world of ruin disguised as another character. Bring that character to him to recruit him.", "major", "checkbox"),
+    Code('nomiabs', 'NO MIAB MODE', "Chests will never have monster encounters in them", "beta", "checkbox"),
 
-    Code('dancingmaduin', "RESTRICTED ESPERS MODE", "Restricts Esper usage such that most Espers can only be equipped by one character. Also usually changes what spell the Paladin Shld teaches.", "major"),
-    Code('darkworld', "SLASHER'S DELIGHT MODE", "Drastically increases the difficulty of the seed, akin to a hard mode. Mostly meant to be used in conjunction with the madworld code.", "major"),
-    Code('dearestmolulu', "ENCOUNTERLESS MODE", "No random encounters occur. Recommend using with exp code. Wearing a Moogle Charm or a piece of equipment with the Moogle Charm effect will cause a battle to occur on every step when encounters can be occur.", "major"),
-    Code('easymodo', "EASY MODE", "All enemies have 1 HP.", "major"),
-    Code('sketch', "ENABLE SKETCH GLITCH", "Enables sketch glitch. Not recommended unless you know what you are doing.", "gamebreaking"),
+    Code('dancingmaduin', "RESTRICTED ESPERS MODE", "Restricts Esper usage such that most Espers can only be equipped by one character. Also usually changes what spell the Paladin Shld teaches.", "major", "checkbox"),
+    Code('darkworld', "SLASHER'S DELIGHT MODE", "Drastically increases the difficulty of the seed, akin to a hard mode. Mostly meant to be used in conjunction with the madworld code.", "major", "checkbox"),
+    Code('dearestmolulu', "ENCOUNTERLESS MODE", "No random encounters occur. Recommend using with exp code. Wearing a Moogle Charm or a piece of equipment with the Moogle Charm effect will cause a battle to occur on every step when encounters can be occur.", "major", "checkbox"),
+    Code('easymodo', "EASY MODE", "All enemies have 1 HP.", "major", "checkbox"),
+    Code('sketch', "ENABLE SKETCH GLITCH", "Enables sketch glitch. Not recommended unless you know what you are doing.", "gamebreaking", "checkbox"),
     
-    Code('equipanything', "EQUIP ANYTHING MODE", "Items that are not equippable normally can now be equipped as weapons or shields. These often give strange defensive stats or weapon animations.", "gamebreaking"),
+    Code('equipanything', "EQUIP ANYTHING MODE", "Items that are not equippable normally can now be equipped as weapons or shields. These often give strange defensive stats or weapon animations.", "gamebreaking", "checkbox"),
     
-    Code('madworld', "TIERS FOR FEARS MODE", 'Creates a "true tierless" seed, with enemies having a higher degree of randomization and shops being very randomized as well.', "major"),
-    
-    
-    Code('metronome', "R-CHAOS MODE", "All characters have Fight, R-Chaos, Magic, and Item as their skillset, except for the Mime, who has Mimic instead of Fight. Berserker also only has R-Chaos.", "major"),
-    
-    Code('naturalmagic', "NATURAL MAGIC MODE", "No Espers or equipment will teach spells. The only way to learn spells is through Natural Magic.", "major"),
-    
-    Code('norng', "NO RNG MODE", "Calls to the RNG are not made. Attacks are always critical hits, everything targets the lead character when applicable, and all attacks hit if they are able to except Instant Death. Many more additional effects occur. Cannot currently be completed without cheat codes.", "experimental"),
+    Code('madworld', "TIERS FOR FEARS MODE", 'Creates a "true tierless" seed, with enemies having a higher degree of randomization and shops being very randomized as well.', "major", "checkbox"),
     
     
-    Code('playsitself', "AUTOBATTLE MODE", "All characters will act automatically, in a manner similar to when Coliseum fights are fought.", "major"),
+    Code('metronome', "R-CHAOS MODE", "All characters have Fight, R-Chaos, Magic, and Item as their skillset, except for the Mime, who has Mimic instead of Fight. Berserker also only has R-Chaos.", "major", "checkbox"),
     
-    Code('randomboost', "RANDOM BOOST MODE", "Prompts you for a randomness multiplier, which changes the range of items that can be in chests, etc. Choosing a randomness multiplier of 0(or leaving it blank) will allow any item to appear in any treasure chest.", "major"),
+    Code('naturalmagic', "NATURAL MAGIC MODE", "No Espers or equipment will teach spells. The only way to learn spells is through Natural Magic.", "major", "checkbox"),
     
-    Code('repairpalette', "PALETTE REPAIR", "Used for testing changes to palette randomization. Not intended for actual play. Cannot proceed past Banon's scenario.", "experimental"),
+    Code('norng', "NO RNG MODE", "Calls to the RNG are not made. Attacks are always critical hits, everything targets the lead character when applicable, and all attacks hit if they are able to except Instant Death. Many more additional effects occur. Cannot currently be completed without cheat codes.", "experimental", "checkbox"),
     
-    Code('rushforpower', "OLD VARGAS FIGHT MODE", "Reverts the Vargas fight to the way it was before Beyond Chaos EX.", "major"),
-    Code('strangejourney', "BIZARRE ADVENTURE", "A prototype entrance Randomizer, similar to the ancientcave mode. Includes all maps and event tiles, and is usually extremely hard to beat by itself.", "experimental"),
     
-    Code('suplexwrecks', "SUPLEX MODE", "All characters use the Sabin sprite, as well as having a name similar to Sabin. All characters have the Blitz and Suplex commands, and every enemy can be hit by Suplex.", "major"),
-    Code('thescenarionottaken', 'DIVERGENT PATHS MODE', "Changes the way the 3 scenarios are split up.", "experimental"),
-    Code('worringtriad', "START IN WOR", "The player will start in the World of Ruin, with all of the World of Balance treasure chests, along with a guaranteed set of items, and more Lores.", "major"),
+    Code('playsitself', "AUTOBATTLE MODE", "All characters will act automatically, in a manner similar to when Coliseum fights are fought.", "major", "checkbox"),
     
-    Code('desperation', "When all options fail", "When the adventurer back is up against the wall. Break the wall.", "beta"),
-    #Code('sixtytwoqd', "version 62 randomizer", "For quickdraw only, run version 62 of the randomizer", "beta"),
+    Code('randomboost', "RANDOM BOOST MODE", "Prompts you for a randomness multiplier, which changes the range of items that can be in chests, etc. Choosing a randomness multiplier of 0(or leaving it blank) will allow any item to appear in any treasure chest.", "major", "numberbox"),
+    
+    Code('repairpalette', "PALETTE REPAIR", "Used for testing changes to palette randomization. Not intended for actual play. Cannot proceed past Banon's scenario.", "experimental", "checkbox"),
+    
+    Code('rushforpower', "OLD VARGAS FIGHT MODE", "Reverts the Vargas fight to the way it was before Beyond Chaos EX.", "major", "checkbox"),
+    Code('strangejourney', "BIZARRE ADVENTURE", "A prototype entrance Randomizer, similar to the ancientcave mode. Includes all maps and event tiles, and is usually extremely hard to beat by itself.", "experimental", "checkbox"),
+    
+    Code('suplexwrecks', "SUPLEX MODE", "All characters use the Sabin sprite, as well as having a name similar to Sabin. All characters have the Blitz and Suplex commands, and every enemy can be hit by Suplex.", "major", "checkbox"),
+    Code('thescenarionottaken', 'DIVERGENT PATHS MODE', "Changes the way the 3 scenarios are split up.", "experimental", "checkbox"),
+    Code('worringtriad', "START IN WOR", "The player will start in the World of Ruin, with all of the World of Balance treasure chests, along with a guaranteed set of items, and more Lores.", "major", "checkbox"),
+    
+    Code('desperation', "When all options fail", "When the adventurer back is up against the wall. Break the wall.", "beta", "checkbox"),
+    #Code('sixtytwoqd', "version 62 randomizer", "For quickdraw only, run version 62 of the randomizer", "beta", "checkbox"),
 ]
 
 #these are all sprite related codes
 MAKEOVER_MODIFIER_CODES = [
-    Code('novanilla', "COMPLETE MAKEOVER MODE", "Same as 'makeover' except sprites from the vanilla game are guaranteed not to appear.", "sprite"),
-    Code('frenchvanilla', "EQUAL RIGHTS MAKEOVER MODE", "Same as 'makeover' except sprites from the vanilla game are selected with equal weight to new sprites rather than some being guaranteed to appear.", "sprite"),
-    Code('cloneparty', "CLONE COSPLAY MAKEOVER MODE", "Same as 'makeover' except instead of avoiding choosing different versions of the same character, it actively tries to do so.", "sprite")
+    Code('novanilla', "COMPLETE MAKEOVER MODE", "Same as 'makeover' except sprites from the vanilla game are guaranteed not to appear.", "sprite", "checkbox"),
+    Code('frenchvanilla', "EQUAL RIGHTS MAKEOVER MODE", "Same as 'makeover' except sprites from the vanilla game are selected with equal weight to new sprites rather than some being guaranteed to appear.", "sprite", "checkbox"),
+    Code('cloneparty', "CLONE COSPLAY MAKEOVER MODE", "Same as 'makeover' except instead of avoiding choosing different versions of the same character, it actively tries to do so.", "sprite", "checkbox")
 ]
 RESTRICTED_VANILLA_SPRITE_CODES = []
 
 #this is used for the no codes and only codes for sprites
 makeover_groups = ["anime", "boys", "generic", "girls", "kids", "pets", "potato", "custom"]
 for mg in makeover_groups:
-    no = Code('no'+mg, f"NO {mg.upper()} ALLOWED MODE", f"Do not select {mg} sprites.", "spriteCategories")
+    no = Code('no'+mg, f"NO {mg.upper()} ALLOWED MODE", f"Do not select {mg} sprites.", "spriteCategories", "checkbox")
     MAKEOVER_MODIFIER_CODES.extend([
         no,
-        Code('only'+mg, f"{mg.upper()} WORLD MODE", f"Select only {mg} sprites.", "spriteCategories")])
+        Code('only'+mg, f"{mg.upper()} WORLD MODE", f"Select only {mg} sprites.", "spriteCategories", "checkbox")])
     RESTRICTED_VANILLA_SPRITE_CODES.append(no)
 
 
 # TODO: do this a better way
 CAVE_CODES = [
-    Code('ancientcave', "ANCIENT CAVE MODE", "", "cave"),
-    Code('speedcave', "SPEED CAVE MODE", "", "cave"),
-    Code('racecave', "RACE CAVE MODE", "", "cave"),
+    Code('ancientcave', "ANCIENT CAVE MODE", "", "cave", "checkbox"),
+    Code('speedcave', "SPEED CAVE MODE", "", "cave", "checkbox"),
+    Code('racecave', "RACE CAVE MODE", "", "cave", "checkbox"),
 ]
 
 
 SPECIAL_CODES = [
-    Code('christmas', 'CHIRSTMAS MODE', '', 'holiday'),
-    Code('halloween', "ALL HALLOWS' EVE MODE", '', 'holiday')
+    Code('christmas', 'CHIRSTMAS MODE', '', 'holiday', "checkbox"),
+    Code('halloween', "ALL HALLOWS' EVE MODE", '', 'holiday', "checkbox")
 ]
 
 BETA_CODES = [

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -4448,7 +4448,7 @@ def randomize(args: List[str]) -> str:
             while True:
                 #Input loop to make sure we get a valid directory
                 previous_output = f" (blank for previous: {previous_output_directory})"
-                output_directory = input(f"Please input the directory to place the randomized ROM file. {previous_output}:\n> ").strip().replace('\\', '/')
+                output_directory = input(f"Please input the directory to place the randomized ROM file. {previous_output}:\n> ").strip()
                 print()
 
                 if previous_output_directory and not output_directory:
@@ -4615,7 +4615,7 @@ def randomize(args: List[str]) -> str:
             config['ROM']['Path'] = sourcefile
 
             #Save the output directory
-            if str(output_directory).lower() == str(sourcefile[:str(sourcefile).rindex('/')]).lower():
+            if str(output_directory).lower() == str(os.path.dirname(sourcefile)).lower():
                 #If the output directory is the same as the ROM directory, save an empty string
                 config['ROM']['Output'] = ''
             else:

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -82,7 +82,7 @@ VERSION_ROMAN = "I"
 if BETA:
     VERSION_ROMAN += " BETA"
 TEST_ON = False
-TEST_SEED = "4.normal.bcdefgijklmnopqrstuwyzcapslockoffmakeovernotawaiterpartypartydancingmaduinbsiabmimetimerandombosseseasymodocanttouchthisjohnnydmad.1625797275"
+TEST_SEED = "1.normal.bcdefgijklmnopqrstuwyzcapslockoffmakeovernotawaiterpartypartydancingmaduinbsiabmimetimerandombosseseasymodocanttouchthisjohnnydmad.1625797275"
 TEST_FILE = "FF3.smc"
 seed, flags = None, None
 seedcounter = 1
@@ -2786,7 +2786,7 @@ def manage_dragons():
         fout.write(bytes([dragon]))
 
 
-def manage_formations(formations: List[Formation], fsets: List[FormationSet]) -> List[Formation]:
+def manage_formations(formations: List[Formation], fsets: List[FormationSet], apMultiplier: float=None) -> List[Formation]:
     for fset in fsets:
         if len(fset.formations) == 4:
             for formation in fset.formations:
@@ -2847,7 +2847,15 @@ def manage_formations(formations: List[Formation], fsets: List[FormationSet]) ->
                            0x1E0, 0x1E6]}
 
     for formation in formations:
-        formation.mutate(ap=False)
+        if Options_.is_code_active('mps'):
+            if apMultiplier:
+                formation.mutate(ap=False, apMultiplier=apMultiplier)
+            else:
+                print("apMultiplier does not exist.")
+                formation.mutate(ap=False, apMultiplier=3)
+        else:
+            print("mps code is not on")
+            formation.mutate(ap=False)
         if formation.formid == 0x1e2:
             formation.set_music(2)  # change music for Atma fight
         if formation.formid == 0x162:
@@ -2862,11 +2870,12 @@ def manage_formations(formations: List[Formation], fsets: List[FormationSet]) ->
 def manage_formations_hidden(formations: List[Formation],
                              freespaces: List[FreeBlock],
                              form_music_overrides: dict=None,
-                             no_special_events=True):
+                             no_special_events=True,
+                             apMultiplier: float=None):
     if not form_music_overrides:
         form_music_overrides = {}
     for f in formations:
-        f.mutate(ap=True)
+        f.mutate(ap=True, apMultiplier=apMultiplier)
 
     unused_enemies = [u for u in get_monsters() if u.id in REPLACE_ENEMIES]
 
@@ -4386,7 +4395,8 @@ def diverge(fout: BinaryIO):
         fout.write(data)
 
 
-def randomize(args: List[str]) -> str:
+#def randomize(args: List[str]) -> str:
+def randomize(**kwargs) -> str:
     """
     The main function which takes in user arguments and creates a log
     and outfile. Returns a path (as str) to the output file.
@@ -4395,10 +4405,12 @@ def randomize(args: List[str]) -> str:
     global outfile, sourcefile, flags, seed, fout, ALWAYS_REPLACE, NEVER_REPLACE
 
     if TEST_ON:
-        while len(args) < 3:
-            args.append(None)
-        args[1] = TEST_FILE
-        args[2] = TEST_SEED
+        #while len(args) < 3:
+        #    args.append(None)
+        #args[1] = TEST_FILE
+        #args[2] = TEST_SEED
+        kwargs['sourcefile'] = TEST_FILE
+        kwargs['seed'] = TEST_SEED
     sleep(0.5)
     print('You are using Beyond Chaos CE Randomizer version "%s".' % VERSION)
     if BETA:
@@ -4406,19 +4418,23 @@ def randomize(args: List[str]) -> str:
 
     previous_rom_path = ''
     previous_output_directory = ''
-    if len(args) > 2:
-        sourcefile = args[1].strip()
-    else:
+
+    sourcefile = kwargs.get('sourcefile')
+    #if len(args) > 2:
+        #sourcefile = args[1].strip()
+    #else:
+    if not sourcefile:
         try:
             config = configparser.ConfigParser()
             config.read('bcex.cfg')
             if 'ROM' in config:
                 previous_rom_path = config['ROM']['Path']
                 previous_output_directory = config['ROM']['Output']
-        except (IOError, KeyError):
+        except (IOError, KeyError) as e:
+            print(str(e))
             pass
 
-        previous_input = f" (blank for previous: {previous_rom_path})" if previous_rom_path else ""
+        previous_input = f" (blank for default: {previous_rom_path})" if previous_rom_path else ""
         sourcefile = input(f"Please input the file name of your copy of "
                            f"the FF3 US 1.0 rom{previous_input}:\n> ").strip()
         print()
@@ -4436,18 +4452,20 @@ def randomize(args: List[str]) -> str:
         f = open(sourcefile, 'rb')
         data = f.read()
         f.close()
-
-        if len(args) > 4:
+        
+        output_directory = kwargs.get('output_directory')
+        #if len(args) > 4:
             #If a directory was supplied by the GUI, use that directory
-            output_directory = args[4]
-        else:
+            #output_directory = args[4]
+        #else:
+        if not output_directory:
             #If no previous directory or an invalid directory was obtained from bcex.cfg, default to the ROM's directory
             if not previous_output_directory or not os.path.isdir(previous_output_directory):
                 previous_output_directory = os.path.dirname(sourcefile)
 
             while True:
                 #Input loop to make sure we get a valid directory
-                previous_output = f" (blank for previous: {previous_output_directory})"
+                previous_output = f" (blank for default: {previous_output_directory})"
                 output_directory = input(f"Please input the directory to place the randomized ROM file. {previous_output}:\n> ").strip()
                 print()
 
@@ -4500,9 +4518,12 @@ def randomize(args: List[str]) -> str:
 -   Use all flags EXCEPT the ones listed'''
 
     speeddial_opts = {}
-
-    if len(args) > 2:
-        fullseed = args[2].strip()
+    
+    fullseed = kwargs.get('seed')
+    #if len(args) > 2:
+        #fullseed = args[2].strip()
+    if fullseed:
+        fullseed = str(fullseed).strip()
     else:
         fullseed = input("Please input a seed value (blank for a random "
                          "seed):\n> ").strip()
@@ -4690,8 +4711,11 @@ def randomize(args: List[str]) -> str:
     print(activation_string)
 
     if Options_.is_code_active('randomboost'):
-        x = input("Please enter a randomness "
-                  "multiplier value (blank for tierless): ")
+        if 'randomboost' in kwargs and kwargs.get('randomboost') is not None:
+            x = kwargs.get('randomboost')
+        else:
+            x = input("Please enter a randomness "
+                    "multiplier value (blank for tierless): ")
         try:
             multiplier = float(x)
             if multiplier <= 0:
@@ -4913,7 +4937,10 @@ def randomize(args: List[str]) -> str:
     if Options_.random_formations:
         formations = get_formations()
         fsets = get_fsets()
-        manage_formations(formations, fsets)
+        if Options_.is_code_active('mps'):
+            manage_formations(formations, fsets, kwargs.get('mpMultiplier'))
+        else:
+            manage_formations(formations, fsets)
         for fset in fsets:
             fset.write_data(fout)
 
@@ -4936,7 +4963,10 @@ def randomize(args: List[str]) -> str:
     form_music = {}
     if Options_.random_formations:
         no_special_events = not Options_.is_code_active('bsiab')
-        manage_formations_hidden(formations, freespaces=aispaces, form_music_overrides=form_music, no_special_events=no_special_events)
+        if Options_.is_code_active('mps'):
+            manage_formations_hidden(formations, freespaces=aispaces, form_music_overrides=form_music, no_special_events=no_special_events, apMultiplier=kwargs.get('mpMultiplier'))
+        else:
+            manage_formations_hidden(formations, freespaces=aispaces, form_music_overrides=form_music, no_special_events=no_special_events)
         for m in get_monsters():
             m.write_stats(fout)
     reseed()
@@ -5102,11 +5132,17 @@ def randomize(args: List[str]) -> str:
             if Options_.is_code_active('llg'):
                 m.stats['xp'] = 0
             if Options_.is_code_active('exp'):
-                m.stats['xp'] = min(0xFFFF, 3 * m.stats['xp'])
+                if 'expMultiplier' in kwargs:
+                    m.stats['xp'] = min(0xFFFF, kwargs.get('expMultiplier') * m.stats['xp'])
+                else:
+                    m.stats['xp'] = min(0xFFFF, 3 * m.stats['xp'])
             m.write_stats(fout)
 
     if Options_.is_code_active('gp'):
         for m in monsters:
+            if 'gpMultiplier' in kwargs:
+                m.stats['gp'] = min(0xFFFF, kwargs.get('gpMultiplier') * m.stats['gp'])
+            else:
                 m.stats['gp'] = min(0xFFFF, 3 * m.stats['gp'])
 
     if Options_.is_code_active('naturalmagic') or Options_.is_code_active('naturalstats'):
@@ -5224,21 +5260,82 @@ def randomize(args: List[str]) -> str:
 
 if __name__ == "__main__":
     args = list(argv)
-    if len(argv) > 3 and argv[3].strip().lower() == "test" or TEST_ON:
-        randomize(args=args)
+    #if len(argv) > 3 and argv[3].strip().lower() == "test" or TEST_ON:
+    #    randomize(args=args)
+    #    sys.exit()
+    if len(args) > 1 and args[1] == '?':
+        print(
+            '\tBeyond Chaos Randomizer Community Edition, version ' + VERSION + '\n',
+            '\t\tOptional Keyword Arguments:\n',
+            '\t\tsource=<file path to your unrandomized Final Fantasy 3 v1.0 ROM file>\n',
+            '\t\tdestination=<directory path where you want the randomized ROM and spoiler log created>\n',
+            '\t\tseed=<flag and seed information in the format version.mode.flags.seed>\n'
+            '\t\texpmultplier=<The desired positive integer EXP multiplier, if you are using the exp code>\n',
+            '\t\tgpmultplier=<The desired positive integer GP multiplier, if you are using the gp code>\n',
+            '\t\trandomboost=<The desired positive integer randomboost amount, if you are using the randomboost code>\n',
+        )
         sys.exit()
     try:
-        randomize(args=args)
-        input("Press enter to close this program. ")
+        source_arg = None
+        seed_arg = None
+        destination_arg = None
+        expMultiplier = 3
+        gpMultiplier = 3
+        mpMultiplier = 3
+        randomboost = None
+        for argument in args[1:]:
+            if 'source=' in argument:
+                source_arg = argument[argument.index('=') + 1:]
+            elif 'seed=' in argument:
+                seed_arg = argument[argument.index('=') + 1:]
+            elif 'destination=' in argument:
+                destination_arg = argument[argument.index('=') + 1:]
+            elif 'expmultiplier=' in argument:
+                try:
+                    expMultiplier = float(argument[argument.index('=') + 1:])
+                except ValueError:
+                    print("The supplied value for the exp multiplier was not a number.")
+                    sys.exit()
+            elif 'gpmultiplier=' in argument:
+                try:
+                    gpMultiplier = float(argument[argument.index('=') + 1:])
+                except ValueError:
+                    print("The supplied value for the gp multiplier was not a number.")
+                    sys.exit()
+            elif 'gpmultiplier=' in argument:
+                try:
+                    mpMultiplier = float(argument[argument.index('=') + 1:])
+                except ValueError:
+                    print("The supplied value for the mp multiplier was not a number.")
+                    sys.exit()
+            elif 'randomboost=' in argument:
+                try:
+                    randomboost = int(argument[argument.index('=') + 1:])
+                except ValueError:
+                    print("The supplied value for randomboost was not a number.")
+                    sys.exit()
+            else:
+                print('Keyword unrecognized or missing: ' + str(argument) + '.\nUse "python randomizer.py ?" to view a list of valid keyword arguments.')
+
+        randomize(
+            sourcefile=source_arg, 
+            seed=seed_arg, 
+            output_directory=destination_arg, 
+            expMultiplier=expMultiplier, 
+            gpMultiplier=gpMultiplier, 
+            mpMultiplier=mpMultiplier, 
+            randomboost=randomboost
+        )
+        input('Press enter to close this program.')
     except Exception as e:
-        print("ERROR: %s" % e)
+        print('ERROR: %s' % e, '\nTo view valid keyword arguments, use "python randomizer.py ?"')
         import traceback
         traceback.print_exc()
         if fout:
             fout.close()
         if outfile is not None:
-            print("Please try again with a different seed.")
-            input("Press enter to delete %s and quit. " % outfile)
+            print('Please try again with a different seed.')
+            input('Press enter to delete %s and quit. ' % outfile)
             os.remove(outfile)
         else:
-            input("Press enter to quit. ")
+            input('Press enter to quit.')

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -2851,10 +2851,8 @@ def manage_formations(formations: List[Formation], fsets: List[FormationSet], ap
             if apMultiplier:
                 formation.mutate(ap=False, apMultiplier=apMultiplier)
             else:
-                print("apMultiplier does not exist.")
                 formation.mutate(ap=False, apMultiplier=3)
         else:
-            print("mps code is not on")
             formation.mutate(ap=False)
         if formation.formid == 0x1e2:
             formation.set_music(2)  # change music for Atma fight

--- a/BeyondChaos/utils.py
+++ b/BeyondChaos/utils.py
@@ -322,6 +322,7 @@ def read_multi(f, length=2, reverse=True):
 def write_multi(f, value, length=2, reverse=True):
     vals = []
     while value:
+        value = int(value)
         vals.append(value & 0xFF)
         value = value >> 8
     if len(vals) > length:


### PR DESCRIPTION
- Applied emberling's directory fixes to a couple of additional places in the code.
- randomizer.randomize() now uses kwargs instead of args. Instead of requiring that arguments that are sent in a specific order, users can now send arguments in any order with a keyword=value syntax. For example, to specify the output directory, a user can now do "destination=<directory>", or to specify a value for randomboost, randomboost=<integer value>.
- Adjusted the flagboxlayout to use QGridLayout instead of QVBoxLayout.
- The randomboost code now uses a QSpinBox instead of a QCheckbox. The QSpinBoxe starts at the minimum value of -1, set as a special "Off" value. If the value is "Off", the code is off, otherwise the code is on. When a value is given this way, users are no longer prompted for a randomboost value in the CLI.
- The exp, gp, and mps codes now have QDoubleSpinBoxes instead of QCheckboxes. These QDoubleSpinBoxes start at the minimum value of -1, set as a special "Off" value. If the value is "Off", the code is off, otherwise the code is on. The values can be set in increments of tenths of a percent starting at 0, meaning users can remove, reduce, or increase exp, gp, and mp by a desired amount.
- Removed llg code. The exp code now does everything llg did and more.

TODO: When the user turns on randomboost, exp, gp, or mps and then changes presets, the code is removed from the list of active codes, but the Q(Double)SpinBox value does not reset.