### PR TITLE
GP Code and QSpinBox bug fixes.

### DIFF
--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -471,7 +471,7 @@ class Window(QWidget):
                     tablayout.addWidget(cbox, currentRow, 1, 1, 2)
                     cbox.clicked.connect(lambda checked: self.flagButtonClicked())
                 elif  flagdesc['inputtype'] == 'numberbox':
-                    if flagname in ['exp','gp', 'mps']:
+                    if flagname in ['exp', 'gp', 'mps']:
                         nbox = QDoubleSpinBox()
                     else:
                         nbox = QSpinBox()
@@ -480,7 +480,7 @@ class Window(QWidget):
                     nbox.setMinimum(-1)
                     nbox.setValue(nbox.minimum())
                     nbox.setMaximum(50)
-                    if flagname in ['exp','gp', 'mps']:
+                    if flagname in ['exp', 'gp', 'mps']:
                         nbox.setFixedWidth(70)
                         nbox.setMinimum(-0.1)
                         nbox.setValue(-0.1)
@@ -879,14 +879,14 @@ class Window(QWidget):
             children = t.findChildren(QSpinBox) + t.findChildren(QDoubleSpinBox)
             for c in children:
                 if c.text == 'exp':
-                    self.expMultiplier = c.value()
+                    self.expMultiplier = round(c.value(), 1)
                 elif c.text == 'gp':
-                    self.gpMultiplier = c.value()
+                    self.gpMultiplier = round(c.value(), 1)
                 elif c.text == 'mps':
-                    self.mpMultiplier = c.value()
+                    self.mpMultiplier = round(c.value(), 1)
                 elif c.text == 'randomboost':
-                    self.randomboost = c.value()
-                if not c.value() == c.minimum():
+                    self.randomboost = round(c.value(), 1)
+                if not round(c.value(), 1) == c.minimum():
                     flagset = False
                     for flag in self.flags:
                         if flag == c.text:

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -5156,6 +5156,7 @@ def randomize(**kwargs) -> str:
                 m.stats['gp'] = min(0xFFFF, kwargs.get('gpMultiplier') * m.stats['gp'])
             else:
                 m.stats['gp'] = min(0xFFFF, 3 * m.stats['gp'])
+            m.write_stats(fout)
 
     if Options_.is_code_active('naturalmagic') or Options_.is_code_active('naturalstats'):
         espers = get_espers(sourcefile)


### PR DESCRIPTION
Fixed GP code not working. The values were not being written to the ROM.

Sometimes QSpinBox values would be like 1.899999 instead of 1.9. Because the program denotes "Off" by a value of -1.0, sometimes the value would end up as -0.99999, which failed to turn off the code. Rounding fixes this and ensures the values used to randomize match what is seen in the GUI.