### PR TITLE
Fixed multiprocessing bug with console

### DIFF
--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -19,12 +19,12 @@ from PyQt5.QtWidgets import (QPushButton, QCheckBox, QWidget, QVBoxLayout,
                              QDialogButtonBox)
 
 # Local application imports
-import randomizer
 import utils
 import customthreadpool
 from config import (readFlags, writeFlags)
 from options import (ALL_FLAGS, NORMAL_CODES, MAKEOVER_MODIFIER_CODES)
 from update import (update, update_needed)
+from randomizer import randomize
 
 if sys.version_info[0] < 3:
     raise Exception("Python 3 or a more recent version is required. "
@@ -1266,7 +1266,7 @@ class Window(QWidget):
                         }
                         # pool = multiprocessing.Pool()
                         pool = customthreadpool.NonDaemonPool(1)
-                        x = pool.apply_async(func=randomizer.randomize, kwds=kwargs)
+                        x = pool.apply_async(func=randomize, kwds=kwargs)
                         x.get()
                         pool.close()
                         pool.join()

--- a/BeyondChaos/customthreadpool.py
+++ b/BeyondChaos/customthreadpool.py
@@ -1,4 +1,5 @@
 import multiprocessing.pool
+from threading import Thread
 
 
 class NonDaemonProcess(multiprocessing.Process):
@@ -8,8 +9,10 @@ class NonDaemonProcess(multiprocessing.Process):
     # make 'daemon' attribute always return False
     def _get_daemon(self):
         return False
+
     def _set_daemon(self, value):
         pass
+
     daemon = property(_get_daemon, _set_daemon)
 
 
@@ -17,4 +20,23 @@ class NonDaemonProcess(multiprocessing.Process):
 # because the latter is only a wrapper function, not a proper class.
 class NonDaemonPool(multiprocessing.pool.Pool):
     Process = NonDaemonProcess
+
+class ThreadWithReturnValue(Thread):
+    def __init__(self, group=None, target=None, name=None,
+                 args=(), kwargs={}, Verbose=None):
+        Thread.__init__(self, group, target, name, args, kwargs)
+        self._return = None
+
+    def run(self):
+        try:
+            if self._target is not None:
+                self._return = self._target(*self._args,
+                                                    **self._kwargs)
+        except:
+            pass
+
+    def join(self, *args):
+        Thread.join(self, *args)
+        return self._return
+
 

--- a/BeyondChaos/remonsterate/remonsterate.py
+++ b/BeyondChaos/remonsterate/remonsterate.py
@@ -1,4 +1,3 @@
-import imp
 import os
 from .tools.tablereader import (
     set_global_label, set_global_table_filename, determine_global_table,


### PR DESCRIPTION
Python's interactive interpreter, used by the console version, does not work with Thread Pools.

beyondchaos.py:
- Slight efficiency improvement to imports

randomizer.py:
- Added logic to use a custom Thread instead of the NonDaemonThreadPool when the console version is being used, since Thread Pools do not work with the interactive interpreter.

customthreadpool.py:
- Added a custom Thread class. This custom class returns a value using join, allowing the Thread to return the remonsterate results that are added to the spoiler log.

remonsterate.py:
- Removed unused import