### PR TITLE
Combobox support for spritecategories

### DIFF
--- a/BeyondChaos/appearance.py
+++ b/BeyondChaos/appearance.py
@@ -412,8 +412,8 @@ def get_sprite_swaps(char_ids, male, female, vswaps):
             og_replacements = [r for r in og_replacements if r.name not in used_vanilla]
         known_replacements.extend(og_replacements)
 
-    #weight selection based on no*/hate*/like*/only* codes
-    whitelist = [c[4:] for c in Options_.active_codes.keys() if c.startswith("only")]
+    # weight selection based on no*/hate*/like*/only* codes
+    whitelist = [c for c in Options_.active_codes.keys() if Options_.get_code_value(c) == "only"]
     replace_candidates = []
     for r in known_replacements:
         whitelisted = False
@@ -422,11 +422,11 @@ def get_sprite_swaps(char_ids, male, female, vswaps):
                 break
             if g in whitelist:
                 whitelisted = True
-            if Options_.is_code_active("no"+g):
+            if Options_.get_code_value(g) == "no":
                 r.weight = 0
-            elif  Options_.is_code_active("hate"+g):
+            elif Options_.get_code_value(g) == "hate":
                 r.weight /= 3
-            elif  Options_.is_code_active("like"+g):
+            elif Options_.get_code_value(g) == "like":
                 r.weight *= 2
         if whitelist and not whitelisted:
             r.weight = 0

--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -22,7 +22,7 @@ from PyQt5.QtWidgets import (QPushButton, QCheckBox, QWidget, QVBoxLayout,
 import utils
 import customthreadpool
 from config import (readFlags, writeFlags)
-from options import (ALL_FLAGS, NORMAL_CODES, MAKEOVER_MODIFIER_CODES)
+from options import (ALL_FLAGS, NORMAL_CODES, MAKEOVER_MODIFIER_CODES, makeover_groups)
 from update import (update, update_needed)
 from randomizer import randomize
 
@@ -590,8 +590,12 @@ class Window(QWidget):
                         width = max(width, len(choice) * 10)
                     cmbbox.setFixedWidth(width)
                     cmbbox.text = flagname
-                    cmbbox.setCurrentIndex(cmbbox.findText("Vanilla"))
+                    if flagname in makeover_groups:
+                        cmbbox.setCurrentIndex(cmbbox.findText("Normal"))
+                    else:
+                        cmbbox.setCurrentIndex(cmbbox.findText("Vanilla"))
                     flaglbl = QLabel(f"{flagname}  -  {flagdesc['explanation']}")
+                    print(flagname + " : " + cmbbox.currentText())
                     tablayout.addWidget(cmbbox, currentRow, 1)
                     tablayout.addWidget(flaglbl, currentRow, 2)
                     cmbbox.activated[str].connect(lambda: self.flagButtonClicked())
@@ -984,7 +988,10 @@ class Window(QWidget):
                 elif type(child) == QSpinBox or type(child) == QDoubleSpinBox:
                     child.setValue(child.default)
                 elif type(child) == QComboBox:
-                    child.setCurrentIndex(child.findText("Vanilla"))
+                    if child.text in makeover_groups:
+                        child.setCurrentIndex(child.findText("Normal"))
+                    else:
+                        child.setCurrentIndex(child.findText("Vanilla"))
 
     # When flag UI button is checked, update corresponding
     # dictionary values
@@ -1010,13 +1017,8 @@ class Window(QWidget):
                         else:
                             self.flags.append(c.text + ":" + str(round(c.value(), 2)))
                 children = t.findChildren(QComboBox)
-                flagset = False
                 for c in children:
-                    if c.text == "swdtechspeed":
-                        if not c.currentText() == "Vanilla":
-                            self.swdtechspeed = c.currentText().lower()
-                            flagset = True
-                    if flagset:
+                    if c.currentText() not in ["Vanilla", "Normal"]:
                         self.flags.append(c.text.lower() + ":" + c.currentText().lower())
 
             self.updateFlagString()

--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -339,10 +339,8 @@ makeover_groups = ["anime", "boys", "generic", "girls", "kids", "pets", "potato"
 for mg in makeover_groups:
     no = Code('no'+mg, f"NO {mg.upper()} ALLOWED MODE", f"Do not select {mg} sprites.", "spriteCategories", "checkbox")
     MAKEOVER_MODIFIER_CODES.extend([
-        no,
-        Code('hate' + mg, f"RARE {mg.upper()} MODE", f"Reduce probability of selecting {mg} sprites.", "spriteCategories", "checkbox"),
-        Code('like' + mg, f"COMMON {mg.upper()} MODE", f"Increase probability of selecting {mg} sprites.", "spriteCategories", "checkbox"),
-        Code('only'+mg, f"{mg.upper()} WORLD MODE", f"Select only {mg} sprites.", "spriteCategories", "checkbox")])
+        Code(mg, f"RARE {mg.upper()} MODE", f"Reduce probability of selecting {mg} sprites.",
+             "spriteCategories", "combobox", ("Normal", "No", "Hate", "Like", "Only"))])
     RESTRICTED_VANILLA_SPRITE_CODES.append(no)
 
 


### PR DESCRIPTION
options.py:
-Converted the spritecategory codes from a series of checkboxes into a single combobox each.

beyondchaos.py:
-Added support for default values and selection of the new spritecategory comboboxes.

appearance.py:
-Updated the weighting algorithm to use get_code_value instead of is_code_active, since the flags are now in key:value format instead of boolean.