### PR TITLE
Update Prompting, Error Handling and Validation

### DIFF
--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import (QPushButton, QCheckBox, QWidget, QVBoxLayout,
 import utils
 import customthreadpool
 from config import (read_flags, write_flags, validate_files, are_updates_hidden, updates_hidden,
-                    get_input_path, get_output_path)
+                    get_input_path, get_output_path, save_version)
 from options import (ALL_FLAGS, NORMAL_CODES, MAKEOVER_MODIFIER_CODES, makeover_groups)
 from update import (get_updater)
 from randomizer import randomize
@@ -1442,6 +1442,8 @@ if __name__ == "__main__":
                         update_dismiss_message.close()
                         updates_hidden(True)
             elif button_clicked == QMessageBox.Ok:
+                if required_update:
+                    save_version('core', 'Error')
                 update_bc()
                 sys.exit()
         window = Window()

--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -20,9 +20,10 @@ from PyQt5.QtWidgets import (QPushButton, QCheckBox, QWidget, QVBoxLayout,
 # Local application imports
 import utils
 import customthreadpool
-from config import (readFlags, writeFlags)
+from config import (read_flags, write_flags, validate_files, are_updates_hidden, updates_hidden,
+                    get_input_path, get_output_path)
 from options import (ALL_FLAGS, NORMAL_CODES, MAKEOVER_MODIFIER_CODES, makeover_groups)
-from update import (update_needed, get_updater)
+from update import (get_updater)
 from randomizer import randomize
 
 if sys.version_info[0] < 3:
@@ -140,13 +141,14 @@ class BingoPrompts(QDialog):
 
 
 def update_bc():
-    update_message = QMessageBox()
-    update_message.setWindowTitle("Beyond Chaos Updater")
-    update_message.setText("Beyond Chaos will check for updates to the core randomizer, character sprites, "
-                           "monster sprites. If updates are performed, BeyondChaos.exe will automatically close.")
-    update_message.setStandardButtons(QMessageBox.Cancel | QMessageBox.Ok)
-    button_clicked = update_message.exec()
-    if button_clicked == QMessageBox.Ok:
+    update_prompt = QMessageBox()
+    update_prompt.setWindowTitle("Beyond Chaos Updater")
+    update_prompt.setText("Beyond Chaos will check for updates to the core randomizer, character sprites, and "
+                          "monster sprites. If updates are performed, BeyondChaos.exe will automatically close.")
+    update_prompt.setStandardButtons(QMessageBox.Cancel | QMessageBox.Ok)
+    update_prompt_button_clicked = update_prompt.exec()
+    if update_prompt_button_clicked == QMessageBox.Ok:
+        updates_hidden(False)
         args = ["-pid " + str(os.getpid())]
         os.system('cls' if os.name == 'nt' else 'clear')
         print("Starting Beyond Chaos Updater...\n")
@@ -270,17 +272,17 @@ class Window(QMainWindow):
         # build the UI
         self.createLayout()
 
-        previousRomPath = ""
-        previousOutputDirectory = ""
+        previousRomPath = get_input_path()
+        previousOutputDirectory = get_output_path()
 
-        try:
-            config = configparser.ConfigParser()
-            config.read('bcce.cfg')
-            if 'ROM' in config:
-                previousRomPath = config['ROM']['Path']
-                previousOutputDirectory = config['ROM']['Output']
-        except (IOError, KeyError):
-            pass
+        # try:
+        #     config = configparser.ConfigParser()
+        #     config.read('bcce.cfg')
+        #     if 'ROM' in config:
+        #         previousRomPath = config['ROM']['Path']
+        #         previousOutputDirectory = config['ROM']['Output']
+        # except (IOError, KeyError):
+        #     pass
 
         self.romText = previousRomPath
         self.romOutputDirectory = previousOutputDirectory
@@ -296,17 +298,23 @@ class Window(QMainWindow):
         file_menu.addAction("Quit", App.quit)
         self.menuBar().addMenu(file_menu)
 
-        self.menuBar().addAction("Update", update_bc)
+        menu_separator = self.menuBar().addMenu("|")
+        menu_separator.setEnabled(False)
+
+        if validation_result:
+            self.menuBar().addAction("Update Available", update_bc)
+        else:
+            self.menuBar().addAction("Check for Updates", update_bc)
 
         # Primary Vertical Box Layout
         vbox = QVBoxLayout()
 
-        titleLabel = QLabel("Beyond Chaos Randomizer")
+        title_label = QLabel("Beyond Chaos Randomizer")
         font = QtGui.QFont("Arial", 24, QtGui.QFont.Black)
-        titleLabel.setFont(font)
-        titleLabel.setAlignment(QtCore.Qt.AlignCenter)
-        titleLabel.setMargin(10)
-        vbox.addWidget(titleLabel)
+        title_label.setFont(font)
+        title_label.setAlignment(QtCore.Qt.AlignCenter)
+        title_label.setMargin(10)
+        vbox.addWidget(title_label)
 
         # rom input and output, seed input, generate button
         vbox.addWidget(self.GroupBoxOneLayout())
@@ -884,7 +892,7 @@ class Window(QMainWindow):
             self.GamePresets[text] = (
                     self.flagString.text() + "|" + self.mode
             )
-            writeFlags(
+            write_flags(
                 text,
                 (self.flagString.text() + "|" + self.mode)
             )
@@ -899,7 +907,7 @@ class Window(QMainWindow):
             self.presetBox.setCurrentIndex(index)
 
     def loadSavedFlags(self):
-        flagset = readFlags()
+        flagset = read_flags()
         if flagset != None:
             for text, flags in flagset.items():
                 self.GamePresets[text] = flags
@@ -1375,7 +1383,6 @@ class Window(QMainWindow):
             #   flag value is true
             for c in children:
                 value = c.value
-                # print(value + str(d[value]['checked']))
                 if d[value]['checked']:
                     c.setProperty('checked', True)
                 else:
@@ -1383,7 +1390,7 @@ class Window(QMainWindow):
 
     def updateRomOutputPlaceholder(self, value):
         try:
-            self.romOutput.setPlaceholderText(os.path.dirname(value))
+            self.romOutput.setPlaceholderText(os.path.dirname(os.path.normpath(value)))
         except ValueError:
             pass
 
@@ -1397,11 +1404,57 @@ if __name__ == "__main__":
         "Loading GUI, checking for config file, "
         "updater file and updates please wait."
     )
+    App = QApplication(sys.argv)
     try:
-        if not update_needed():
-            App = QApplication(sys.argv)
-            window = Window()
-            time.sleep(3)
-            sys.exit(App.exec())
-    except Exception:
-        traceback.print_exc()
+        validation_result, required_update = validate_files()
+        if required_update or (validation_result and not are_updates_hidden()):
+            update_message = QMessageBox()
+            update_message.setIcon(QMessageBox.Information)
+            if required_update:
+                update_message.setWindowTitle("An update is required")
+            else:
+                update_message.setWindowTitle("An update is available")
+
+            if required_update:
+                update_message.setText("Files that are required for the randomizer to function properly are missing "
+                                       "from the randomizer directory: \n" + str(validation_result) + "\n\n"
+                                       "Press Ok to launch the updater or Close to exit the program.")
+            else:
+                update_message.setText("Updates to Beyond Chaos are available! \n" + str(validation_result) + "\n\n"
+                                       "Press Ok to launch the updater or Close to skip updating. This pop-up will "
+                                       "only show once per update.")
+            update_message.setStandardButtons(QMessageBox.Close | QMessageBox.Ok)
+            button_clicked = update_message.exec()
+            if button_clicked == QMessageBox.Close:
+                # Update_message informs the user about the update button on the UI.
+                update_message.close()
+                if required_update:
+                    sys.exit()
+                else:
+                    update_dismiss_message = QMessageBox()
+                    update_dismiss_message.setIcon(QMessageBox.Information)
+                    update_dismiss_message.setWindowTitle("Information")
+                    update_dismiss_message.setText("The update will be available using the Update button on the "
+                                                   "randomizer's menu bar.")
+                    update_dismiss_message.setStandardButtons(QMessageBox.Close)
+                    button_clicked = update_dismiss_message.exec()
+                    if button_clicked == QMessageBox.Close:
+                        update_dismiss_message.close()
+                        updates_hidden(True)
+            elif button_clicked == QMessageBox.Ok:
+                update_bc()
+                sys.exit()
+        window = Window()
+        time.sleep(3)
+        sys.exit(App.exec())
+    except Exception as e:
+        error_message = QMessageBox()
+        error_message.setIcon(QMessageBox.Warning)
+        error_message.setWindowTitle("A Fatal Error Occurred")
+        error_message.setText(str(e) + "\n\n\n\n\n" +
+                              "Error Traceback for the Devs: \n" +
+                              traceback.format_exc())
+        error_message.setStandardButtons(QMessageBox.Close)
+        button_clicked = error_message.exec()
+        if button_clicked == QMessageBox.Close:
+            error_message.close()

--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -140,18 +140,23 @@ class BingoPrompts(QDialog):
         return self.spells or self.items or self.monsters or self.abilities
 
 
-def update_bc(wait=False):
-    update_prompt = QMessageBox()
-    update_prompt.setWindowTitle("Beyond Chaos Updater")
-    update_prompt.setText("Beyond Chaos will check for updates to the core randomizer, character sprites, and "
-                          "monster sprites. If updates are performed, BeyondChaos.exe will automatically close.")
-    update_prompt.setStandardButtons(QMessageBox.Cancel | QMessageBox.Ok)
-    update_prompt_button_clicked = update_prompt.exec()
-    if update_prompt_button_clicked == QMessageBox.Ok:
+def update_bc(wait=False, suppress_prompt=False):
+    run_updater = False
+    if not suppress_prompt:
+        update_prompt = QMessageBox()
+        update_prompt.setWindowTitle("Beyond Chaos Updater")
+        update_prompt.setText("Beyond Chaos will check for updates to the core randomizer, character sprites, and "
+                              "monster sprites. If updates are performed, BeyondChaos.exe will automatically close.")
+        update_prompt.setStandardButtons(QMessageBox.Cancel | QMessageBox.Ok)
+        update_prompt_button_clicked = update_prompt.exec()
+        if update_prompt_button_clicked == QMessageBox.Ok:
+            run_updater = True
+
+    if run_updater or suppress_prompt:
         updates_hidden(False)
+        print("Starting Beyond Chaos Updater...\n")
         args = ["-pid " + str(os.getpid())]
         os.system('cls' if os.name == 'nt' else 'clear')
-        print("Starting Beyond Chaos Updater...\n")
         try:
             update_process = subprocess.Popen(args=args, executable="BeyondChaosUpdater.exe")
             if wait:
@@ -1475,7 +1480,7 @@ if __name__ == "__main__":
             elif button_clicked == QMessageBox.Ok:
                 if required_update and not first_time_setup:
                     save_version('core', '0.0')
-                update_bc(wait=True)
+                update_bc(wait=True, suppress_prompt=True)
         window = Window()
         time.sleep(3)
         sys.exit(App.exec())

--- a/BeyondChaos/config.py
+++ b/BeyondChaos/config.py
@@ -1,14 +1,13 @@
+import configparser
+import requests
 from configparser import ConfigParser
 from pathlib import Path
 import os
 config = ConfigParser()
 
-CoreVersion = ""
-SpriteVersion = ""
 
-
-def writeFlags(name, flags):
-    config.read(Path(os.getcwd()+"/config.ini"))
+def write_flags(name, flags):
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
     try:
         config.add_section('Flags')    
     except Exception:
@@ -19,9 +18,9 @@ def writeFlags(name, flags):
         config.write(f)
 
 
-def readFlags():
+def read_flags():
     print("Loading saved flags.")
-    config.read(Path(os.getcwd()+"/config.ini"))
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
     try:
         flags = dict(config.items('Flags'))
     except Exception:
@@ -30,34 +29,144 @@ def readFlags():
     return flags
 
 
-def readConfig():
-    config.read(Path(os.getcwd()+"/config.ini"))
-    CoreVersion = config.get('Version', 'Core') # -> "value1"
-    SpriteVersion= config.get('Version', 'Sprite') # -> "value2"
-    #print config.get('main', 'key3') # -> "value3"
+def read_config():
+    version_information = {}
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
+    # try:
+    #     version_information['updater'] = config.get('Version', 'updater')
+    # except configparser.NoOptionError:
+    #     version_information['updater'] = None
+    try:
+        version_information['core'] = config.get('Version', 'core')
+    except configparser.NoOptionError:
+        version_information['core'] = ''
+    try:
+        version_information['character_sprites'] = config.get('Version', 'character_sprites')
+    except configparser.NoOptionError:
+        version_information['character_sprites'] = ''
+    try:
+        version_information['monster_sprites'] = config.get('Version', 'monster_sprites')
+    except configparser.NoOptionError:
+        version_information['monster_sprites'] = ''
+    return version_information
 
 
-def getCoreVersion():
-    readConfig()
-    return CoreVersion
-
-
-def getSpriteVersion():
-    readConfig()
-    return SpriteVersion
-
-
-def checkINI():
-    my_file = Path(os.getcwd()+"/config.ini")
-    if my_file.is_file():
-        # file exists
-        return True
+def get_input_path():
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
+    if config.has_section('Settings') and config.has_option('Settings', 'input_path'):
+        return config.get('Settings', 'input_path')
     else:
-        return False
+        return ''
+
+
+def save_input_path(path):
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
+    if not config.has_section('Settings'):
+        config.add_section('Settings')
+    config.set('Settings', 'input_path', str(path))
+    with open(Path(os.path.join(os.getcwd(), "config.ini")), 'w') as f:
+        config.write(f)
+
+
+def get_output_path():
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
+    if config.has_section('Settings') and config.has_option('Settings', 'output_path'):
+        return config.get('Settings', 'output_path')
+    else:
+        return ''
+
+
+def save_output_path(path):
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
+    if not config.has_section('Settings'):
+        config.add_section('Settings')
+    config.set('Settings', 'output_path', str(path))
+    with open(Path(os.path.join(os.getcwd(), "config.ini")), 'w') as f:
+        config.write(f)
+
+
+# def get_updater_version():
+#     return read_config()['updater']
+
+
+def get_core_version():
+    return read_config()['core']
+
+
+def get_character_sprite_version():
+    return read_config()['character_sprites']
+
+
+def get_monster_sprite_version():
+    return read_config()['monster_sprites']
+
+
+def check_custom():
+    missing_files = []
+    custom_directory = Path(os.path.join(os.getcwd(), 'custom'))
+    if not custom_directory.is_dir():
+        missing_files.append('/custom/')
+    else:
+        # List of all files in /custom/. Some of these may not be required or may depend on chosen flags, but better
+        #   safe than sorry
+        required_custom_files = ['coralnames.txt', 'dancenames.txt', 'femalenames.txt', 'malenames.txt',
+                                 'mooglenames.txt', 'moves.txt', 'opera.txt', 'passwords.txt', 'poems.txt',
+                                 'songs.txt', 'spritereplacements.txt']
+        for file in required_custom_files:
+            file_path = Path(os.path.join(custom_directory, file))
+            if not file_path.exists():
+                missing_files.append("/custom/" + file)
+
+        opera_directory = Path(os.path.join(custom_directory, 'opera'))
+        if not opera_directory.is_dir():
+            missing_files.append('/custom/opera/')
+        # Put opera files here, if the opera files are required
+
+        character_sprites_directory = Path(os.path.join(custom_directory, 'Sprites'))
+        if not character_sprites_directory.is_dir():
+            missing_files.append('/custom/Sprites/')
+        # Put Sprite files here, if any are required
+
+    return missing_files
+
+
+def check_tables():
+    missing_files = []
+    tables_directory = Path(os.path.join(os.getcwd(), 'tables'))
+    if not tables_directory.is_dir():
+        missing_files.append('/tables/')
+    else:
+        # List of all files in /tables/. Some of these may not be required or may depend on chosen flags, but better
+        #   safe than sorry
+        required_table_files = ['ancientcheckpoints.txt', 'battlebgpalettes.txt', 'charcodes.txt',
+                                 'charpaloptions.txt', 'chestcodes.txt', 'commandcodes.txt', 'customitems.txt',
+                                 'defaultsongs.txt', 'dialoguetext.txt', 'divergentedits.txt', 'enemycodes.txt',
+                                 'enemynames.txt', 'espercodes.txt', 'eventpalettes.txt', 'finalai.txt',
+                                 'finaldungeoncheckpoints.txt', 'finaldungeonmaps.txt', 'formationmusic.txt',
+                                 'generator.txt', 'itemcodes.txt', 'locationformations.txt', 'locationmaps.txt',
+                                 'locationpaletteswaps.txt', 'magicite.txt', 'mapbattlebgs.txt', 'mapnames.txt',
+                                 'reachability.txt', 'ridingsprites.txt', 'samples.txt', 'shopcodes.txt',
+                                 'shorttext.txt', 'skipevents.txt', 'spellbans.txt', 'spellcodes.txt', 'text.txt',
+                                 'treasurerooms.txt', 'unusedlocs.txt', 'usedlocs.txt', 'wobeventbits.txt',
+                                 'wobonlytreasure.txt', 'worstartingitems.txt']
+        for file in required_table_files:
+            file_path = Path(os.path.join(tables_directory, file))
+            if not file_path.exists():
+                missing_files.append("/tables/" + file)
+
+    return missing_files
+
+
+def check_ini():
+    missing_files = []
+    ini_file = Path(os.path.join(os.getcwd(), "config.ini"))
+    if not ini_file.is_file():
+        missing_files.append('config.ini')
+    return missing_files
 
 
 def check_remonsterate():
-    current = True
+    missing_files = []
     base_directory = os.path.join(os.getcwd(), "remonsterate")
     sprite_directory = os.path.join(base_directory, "sprites")
     image_file = os.path.join(base_directory, "images_and_tags.txt")
@@ -65,16 +174,94 @@ def check_remonsterate():
 
     if os.path.isdir(base_directory):
         if not os.path.isfile(image_file):
+            missing_files.append('/remonsterate/images_and_tags')
             print("The images_and_tags.txt file is missing from the remonsterate directory.")
-            current = False
         if not os.path.isfile(monster_file):
+            missing_files.append('/remonsterate/monsters_and_tags.txt')
             print("The monsters_and_tags.txt file is missing from the remonsterate directory.")
-            current = False
         if not os.path.isdir(sprite_directory):
+            missing_files.append('/remonsterate/')
             print("The sprites folder is missing from the remonsterate directory.")
-            current = False
     else:
+        missing_files.append('/remonsterate/')
         print("The remonsterate folder is missing from the Beyond Chaos directory.")
-        current = False
 
-    return current
+    return missing_files
+
+
+def are_updates_hidden():
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
+    if not config.has_section('Settings') or not config.has_option('Settings', 'updates_hidden'):
+        # If the config file does not have this setting, write it and then return false
+        updates_hidden(False)
+        return False
+    try:
+        if config.get('Settings', 'updates_hidden') == "True":
+            return True
+        else:
+            return False
+    except Exception:
+        return False
+
+
+def updates_hidden(hidden=False):
+    config.read(Path(os.path.join(os.getcwd(), "config.ini")))
+    if not config.has_section('Settings'):
+        config.add_section('Settings')
+    config.set('Settings', 'updates_hidden', str(hidden))
+    with open(Path(os.path.join(os.getcwd(), "config.ini")), 'w') as f:
+        config.write(f)
+
+
+def validate_files():
+    # Return values:
+    # 1) Array of strings representing missing information
+    # 2) Boolean that indicates whether the update is required or optional
+    missing_files = []
+    missing_files.extend(check_custom())
+    missing_files.extend(check_tables())
+    missing_files.extend(check_ini())
+    missing_files.extend(check_remonsterate())
+
+    # Missing files are required for the randomizer to function properly, so it triggers a forced update
+    if missing_files:
+        return '\n'.join(missing_files), True
+
+    version_errors = []
+    base_github_url = 'https://api.github.com/repos/FF6BeyondChaos/'
+    core_github_url = base_github_url + 'BeyondChaosRandomizer/releases/latest'
+    character_sprites_github_url = base_github_url + 'BeyondChaosSprites/releases/latest'
+    monster_sprites_github_url = base_github_url + 'BeyondChaosMonsterSprites/releases/latest'
+
+    for type, version in read_config().items():
+        if not version:
+            # Catches version information with no recorded information - probably should never happen
+            version_errors.append('The ' + type + " version was not recorded in config.ini.")
+        else:
+            # Note: Updater version is not checked.
+            if type == 'core':
+                response = requests.get(core_github_url)
+                if response.ok:
+                    github_version = response.json()['tag_name']
+                    if not version == github_version:
+                        version_errors.append('The core Beyond Chaos files are currently version ' + str(version) + '. '
+                                              'Version ' + github_version + ' is available.')
+            if type == 'character_sprites':
+                response = requests.get(character_sprites_github_url)
+                if response.ok:
+                    github_version = response.json()['tag_name']
+                    if not version == github_version:
+                        version_errors.append('The Character Sprite files are currently version ' + str(version) + '. '
+                                              'Version ' + github_version + ' is available.')
+            if type == 'monster_sprites':
+                response = requests.get(monster_sprites_github_url)
+                if response.ok:
+                    github_version = response.json()['tag_name']
+                    if not version == github_version:
+                        version_errors.append('The Monster Sprite files are currently version ' + str(version) + '. '
+                                              'Version ' + github_version + ' is available.')
+
+    if version_errors:
+        return '\n'.join(version_errors), False
+    return None, False
+

--- a/BeyondChaos/config.py
+++ b/BeyondChaos/config.py
@@ -3,8 +3,14 @@ import requests
 from configparser import ConfigParser
 from pathlib import Path
 import os
-config = ConfigParser()
 
+try:
+    from sys import _MEIPASS
+    TABLE_PATH = os.path.dirname(os.path.abspath(__file__))
+except ImportError:
+    TABLE_PATH = os.path.join(os.getcwd(), "tables")
+
+config = ConfigParser()
 CONFIG_PATH = Path(os.path.join(os.getcwd(), "config.ini"))
 
 
@@ -134,8 +140,7 @@ def check_custom():
 
 def check_tables():
     missing_files = []
-    tables_directory = Path(os.path.join(os.getcwd(), 'tables'))
-    if not tables_directory.is_dir():
+    if not TABLE_PATH.is_dir():
         missing_files.append('/tables/')
     else:
         # List of all files in /tables/. Some of these may not be required or may depend on chosen flags, but better
@@ -152,9 +157,10 @@ def check_tables():
                                  'treasurerooms.txt', 'unusedlocs.txt', 'usedlocs.txt', 'wobeventbits.txt',
                                  'wobonlytreasure.txt', 'worstartingitems.txt']
         for file in required_table_files:
-            file_path = Path(os.path.join(tables_directory, file))
+            file_path = Path(os.path.join(TABLE_PATH, file))
             if not file_path.exists():
                 missing_files.append("/tables/" + file)
+    print("Hello")
 
     return missing_files
 
@@ -216,7 +222,7 @@ def validate_files():
     # 2) Boolean that indicates whether the update is required or optional
     missing_files = []
     missing_files.extend(check_custom())
-    missing_files.extend(check_tables())
+    # missing_files.extend(check_tables())
     missing_files.extend(check_ini())
     missing_files.extend(check_remonsterate())
 

--- a/BeyondChaos/dialoguemanager.py
+++ b/BeyondChaos/dialoguemanager.py
@@ -24,11 +24,14 @@ for i in range(0xFF):
 textdialoguetable["63"] = "'"
 
 dialoguebytetable = {}
-for k, v in dialoguetexttable.items():
-    dialoguebytetable[k] = v
-for i in range(0xFF):
-    dialoguebytetable[f"${i:02X}"] = f"{i:02X}"
-dialoguebytetable["'"] = dialoguebytetable["’"]
+try:
+    for k, v in dialoguetexttable.items():
+        dialoguebytetable[k] = v
+    for i in range(0xFF):
+        dialoguebytetable[f"${i:02X}"] = f"{i:02X}"
+    dialoguebytetable["'"] = dialoguebytetable["’"]
+except KeyError:
+    pass
 
 dialogue_vars = {}
 dialogue_flags = set()

--- a/BeyondChaos/locationrandomizer.py
+++ b/BeyondChaos/locationrandomizer.py
@@ -21,31 +21,40 @@ maplocations_override = {}
 
 
 def init():
-    for line in open(MAP_NAMES_TABLE):
-        key, value = tuple(line.strip().split(':'))
-        key = int(key, 0x10)
-        mapnames[key] = value
-    for line in open(MAP_BATTLE_BG_TABLE):
-        a, b = tuple(line.strip().split())
-        mapbattlebgs[int(a)] = int(b, 0x10)
-    for line in open(LOCATION_MAPS_TABLE):
-        a, b, *c = line.strip().split(':')
-        b = b.strip().strip(',').split(',')
-        locids = []
-        for locid in b:
-            if '+' in locid:
-                l = int(locid.strip('+'))
-                locids.extend([l, l + 1, l + 2, l + 3])
-            else:
-                locids.append(int(locid))
+    try:
+        for line in open(MAP_NAMES_TABLE):
+            key, value = tuple(line.strip().split(':'))
+            key = int(key, 0x10)
+            mapnames[key] = value
+    except FileNotFoundError:
+        print("Error: " + MAP_NAMES_TABLE + " was not found in the tables folder.")
+    try:
+        for line in open(MAP_BATTLE_BG_TABLE):
+            a, b = tuple(line.strip().split())
+            mapbattlebgs[int(a)] = int(b, 0x10)
+    except FileNotFoundError:
+        print("Error: " + MAP_BATTLE_BG_TABLE + " was not found in the tables folder.")
+    try:
+        for line in open(LOCATION_MAPS_TABLE):
+            a, b, *c = line.strip().split(':')
+            b = b.strip().strip(',').split(',')
+            locids = []
+            for locid in b:
+                if '+' in locid:
+                    l = int(locid.strip('+'))
+                    locids.extend([l, l + 1, l + 2, l + 3])
+                else:
+                    locids.append(int(locid))
 
-        if a not in maplocations_reverse:
-            maplocations_reverse[a] = []
-        for locid in sorted(locids):
-            maplocations[locid] = a
-            maplocations_reverse[a].append(locid)
-        if c:
-            maplocations_override[a] = c[0]
+            if a not in maplocations_reverse:
+                maplocations_reverse[a] = []
+            for locid in sorted(locids):
+                maplocations[locid] = a
+                maplocations_reverse[a].append(locid)
+            if c:
+                maplocations_override[a] = c[0]
+    except FileNotFoundError:
+        print("Error: " + LOCATION_MAPS_TABLE + " was not found in the tables folder.")
 
 
 init()

--- a/BeyondChaos/namerandomizer.py
+++ b/BeyondChaos/namerandomizer.py
@@ -2,18 +2,29 @@
 
 from utils import (ENEMY_NAMES_TABLE, MODIFIERS_TABLE, MOVES_TABLE,
                    NAMEGEN_TABLE, utilrandom as random)
-
-modifiers = [line.strip() for line in open(MODIFIERS_TABLE)]
-moves = [line.strip() for line in open(MOVES_TABLE)]
-enemynames = [line.strip() for line in open(ENEMY_NAMES_TABLE).readlines()]
+try:
+    modifiers = [line.strip() for line in open(MODIFIERS_TABLE).readlines()]
+except FileNotFoundError:
+    print("Error: " + MODIFIERS_TABLE + " was not found in the custom folder.")
+try:
+    moves = [line.strip() for line in open(MOVES_TABLE).readlines()]
+except FileNotFoundError:
+    print("Error: " + MOVES_TABLE + " was not found in the custom folder.")
+try:
+    enemynames = [line.strip() for line in open(ENEMY_NAMES_TABLE).readlines()]
+except FileNotFoundError:
+    print("Error: " + ENEMY_NAMES_TABLE + " was not found in the tables folder.")
 
 generator = {}
 lookback = None
-for line in open(NAMEGEN_TABLE):
-    key, values = tuple(line.strip().split())
-    generator[key] = values
-    if not lookback:
-        lookback = len(key)
+try:
+    for line in open(NAMEGEN_TABLE):
+        key, values = tuple(line.strip().split())
+        generator[key] = values
+        if not lookback:
+            lookback = len(key)
+except FileNotFoundError:
+    print("Error: " + NAMEGEN_TABLE + " was not found in the tables folder.")
 
 
 def generate_name(size=None, maxsize=10):

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -19,6 +19,8 @@ from ancient import manage_ancient
 from appearance import manage_character_appearance, manage_coral
 from character import get_characters, get_character, equip_offsets
 from chestrandomizer import mutate_event_items, get_event_items
+from config import (read_flags, write_flags, validate_files, are_updates_hidden, updates_hidden,
+                    get_input_path, get_output_path, save_input_path, save_output_path)
 from decompress import Decompressor
 from dialoguemanager import (manage_dialogue_patches, get_dialogue,
                              set_dialogue, read_dialogue,
@@ -4729,15 +4731,17 @@ def randomize(**kwargs) -> str:
     # sourcefile = args[1].strip()
     # else:
     if not sourcefile:
-        try:
-            config = configparser.ConfigParser()
-            config.read('bcce.cfg')
-            if 'ROM' in config:
-                previous_rom_path = config['ROM']['Path']
-                previous_output_directory = config['ROM']['Output']
-        except (IOError, KeyError) as e:
-            print(str(e))
-            pass
+        previous_rom_path = get_input_path()
+        previous_output_directory = get_output_path()
+        # try:
+        #     config = configparser.ConfigParser()
+        #     config.read('bcce.cfg')
+        #     if 'ROM' in config:
+        #         previous_rom_path = config['ROM']['Path']
+        #         previous_output_directory = config['ROM']['Output']
+        # except (IOError, KeyError) as e:
+        #     print(str(e))
+        #     pass
 
         previous_input = f" (blank for default: {previous_rom_path})" if previous_rom_path else ""
         sourcefile = input(f"Please input the file name of your copy of "
@@ -4760,7 +4764,7 @@ def randomize(**kwargs) -> str:
     # else:
     if not output_directory:
         # If no previous directory or an invalid directory was obtained from bcce.cfg, default to the ROM's directory
-        if not previous_output_directory or not os.path.isdir(previous_output_directory):
+        if not previous_output_directory or not os.path.isdir(os.path.normpath(previous_output_directory)):
             previous_output_directory = os.path.dirname(sourcefile)
 
         while True:
@@ -4816,10 +4820,6 @@ def randomize(**kwargs) -> str:
         print("Success! Using valid rom file: %s\n" % sourcefile)
     del f
 
-    saveflags = False
-    if sourcefile != previous_rom_path or output_directory != previous_output_directory:
-        saveflags = True
-
     flaghelptext = '''!   Recommended new player flags
 -   Use all flags EXCEPT the ones listed'''
 
@@ -4836,11 +4836,11 @@ def randomize(**kwargs) -> str:
         print()
 
         if '.' not in fullseed:
-            config = configparser.ConfigParser()
-            config.read('bcce.cfg')
-            #if 'speeddial' in config:
+            # config = configparser.ConfigParser()
+            # config.read('bcce.cfg')
+            # if 'speeddial' in config:
             #    speeddial_opts = config['speeddial']
-            #else:
+            # else:
             #    try:
             #        savedflags = []
             #        with open('savedflags.txt', 'r') as sff:
@@ -4873,15 +4873,15 @@ def randomize(**kwargs) -> str:
             for flag in sorted(allowed_flags):
                 print(flag.name, flag.description)
             print(flaghelptext + "\n")
-            #print("Save frequently used flag sets by adding 0: through 9: before the flags.")
-            #for k, v in sorted(speeddial_opts.items()):
+            # print("Save frequently used flag sets by adding 0: through 9: before the flags.")
+            # for k, v in sorted(speeddial_opts.items()):
             #    print("    %s: %s" % (k, v))
             print()
             flags = input("Please input your desired flags (blank for "
                           "all of them):\n> ").strip()
             if flags == "!" :
                 flags = '-dfklu partyparty makeover johnnydmad'
-            #if " " in flags:
+            # if " " in flags:
                 # flags = flags.split(' ')
                 # dial = ''.join(c for c in flags[0] if c in '0123456789')
                 # if len(dial) == 1:
@@ -4933,32 +4933,35 @@ def randomize(**kwargs) -> str:
                           '.'.join([os.path.basename(tempname[0]),
                                     str(seed), 'txt']))
 
-    if saveflags:
+    if sourcefile != previous_rom_path or output_directory != previous_output_directory:
         try:
-            config = configparser.ConfigParser()
-            config.read('bcce.cfg')
-            if 'ROM' not in config:
-                config['ROM'] = {}
-            if 'speeddial' not in config:
-                config['speeddial'] = {}
-            config['ROM']['Path'] = sourcefile
+            save_input_path(sourcefile)
+            save_output_path(output_directory)
 
-            # Save the output directory
-            if str(output_directory).lower() == str(os.path.dirname(sourcefile)).lower():
-                # If the output directory is the same as the ROM directory, save an empty string
-                config['ROM']['Output'] = ''
-            else:
-                config['ROM']['Output'] = output_directory
-            #config['speeddial'].update({k: v for k, v in speeddial_opts.items() if k != '!'})
-            with open('bcce.cfg', 'w') as cfg_file:
-                config.write(cfg_file)
+            # config = configparser.ConfigParser()
+            # config.read('bcce.cfg')
+            # if 'ROM' not in config:
+            #     config['ROM'] = {}
+            # if 'speeddial' not in config:
+            #     config['speeddial'] = {}
+            # config['ROM']['Path'] = sourcefile
+
+            # # Save the output directory
+            # if str(output_directory).lower() == str(os.path.dirname(sourcefile)).lower():
+            #     # If the output directory is the same as the ROM directory, save an empty string
+            #     config['ROM']['Output'] = ''
+            # else:
+            #     config['ROM']['Output'] = output_directory
+            # #config['speeddial'].update({k: v for k, v in speeddial_opts.items() if k != '!'})
+            # with open('bcce.cfg', 'w') as cfg_file:
+            #     config.write(cfg_file)
         except:
             print("Couldn't save flag string\n")
-        else:
-            try:
-                os.remove('savedflags.txt')
-            except OSError:
-                pass
+        # else:
+        #     try:
+        #         os.remove('savedflags.txt')
+        #     except OSError:
+        #         pass
 
     if len(data) % 0x400 == 0x200:
         print("NOTICE: Headered ROM detected. Output file will have no header.")

--- a/BeyondChaos/skillrandomizer.py
+++ b/BeyondChaos/skillrandomizer.py
@@ -3,26 +3,32 @@ from utils import (hex2int, int2bytes, Substitution, SPELL_TABLE,
 
 spelldict = {}
 spellnames = {}
-f = open(SPELL_TABLE)
-for line in f:
-    line = line.strip()
-    while '  ' in line:
-        line = line.replace('  ', ' ')
-    value, strength, name = tuple(line.split(','))
-    spellnames[hex2int(value)] = name
-f.close()
+try:
+    f = open(SPELL_TABLE)
+    for line in f:
+        line = line.strip()
+        while '  ' in line:
+            line = line.replace('  ', ' ')
+        value, strength, name = tuple(line.split(','))
+        spellnames[hex2int(value)] = name
+    f.close()
+except FileNotFoundError:
+    print("Error: " + SPELL_TABLE + " was not found in the tables folder.")
 
 spellbans = {}
-f = open(SPELLBANS_TABLE)
-for line in f:
-    line = line.strip()
-    if line[0] == '#':
-        continue
-    spellid, modifier, name, ban = tuple(line.split(','))
-    if ban == "ban":
-        modifier = int(modifier) * -1
-    spellbans[hex2int(spellid)] = int(modifier)
-f.close()
+try:
+    f = open(SPELLBANS_TABLE)
+    for line in f:
+        line = line.strip()
+        if line[0] == '#':
+            continue
+        spellid, modifier, name, ban = tuple(line.split(','))
+        if ban == "ban":
+            modifier = int(modifier) * -1
+        spellbans[hex2int(spellid)] = int(modifier)
+    f.close()
+except FileNotFoundError:
+    print("Error: " + SPELLBANS_TABLE + " was not found in the tables folder.")
 
 
 class SpellBlock:

--- a/BeyondChaos/towerrandomizer.py
+++ b/BeyondChaos/towerrandomizer.py
@@ -39,7 +39,10 @@ FIXED_ENTRANCES, REMOVE_ENTRANCES = [], []
 
 locexchange = {}
 old_entrances = {}
-towerlocids = [int(line.strip(), 0x10) for line in open(TOWER_LOCATIONS_TABLE)]
+try:
+    towerlocids = [int(line.strip(), 0x10) for line in open(TOWER_LOCATIONS_TABLE)]
+except FileNotFoundError:
+    print("Error: " + TOWER_LOCATIONS_TABLE + " was not found in the tables folder.")
 map_bans = []
 newfsets = {}
 clusters = None

--- a/BeyondChaos/update.py
+++ b/BeyondChaos/update.py
@@ -41,7 +41,7 @@ def get_updater():
 
 
 def update_needed():
-    up_to_date = config.checkINI() and config.check_remonsterate()
+    up_to_date = config.check_ini() and config.check_remonsterate()
     if not up_to_date:
         print("Running the updater to create necessary files and folders.")
         run_first_time_setup()

--- a/BeyondChaos/utils.py
+++ b/BeyondChaos/utils.py
@@ -137,13 +137,18 @@ class AutoLearnRageSub(Substitution):
 
 
 texttable = {}
-f = open(TEXT_TABLE)
-for line in f:
-    line = line.strip()
-    char, value = tuple(line.split())
-    texttable[char] = value
-texttable[' '] = 'FE'
-f.close()
+try:
+    f = open(TEXT_TABLE)
+    for line in f:
+        line = line.strip()
+        char, value = tuple(line.split())
+        texttable[char] = value
+    texttable[' '] = 'FE'
+    f.close()
+except FileNotFoundError:
+    print("Error: " + TEXT_TABLE + " was not found in the tables folder.")
+
+
 
 
 def name_to_bytes(name, length):
@@ -155,24 +160,30 @@ def name_to_bytes(name, length):
 
 
 shorttexttable = {}
-f = open(SHORT_TEXT_TABLE)
-for line in f:
-    line = line.strip()
-    char, value = tuple(line.split())
-    shorttexttable[char] = value
-shorttexttable[' '] = 'FF'
-f.close()
+try:
+    f = open(SHORT_TEXT_TABLE)
+    for line in f:
+        line = line.strip()
+        char, value = tuple(line.split())
+        shorttexttable[char] = value
+    shorttexttable[' '] = 'FF'
+    f.close()
+except FileNotFoundError:
+    print("Error: " + SHORT_TEXT_TABLE + " was not found in the tables folder.")
 
 dialoguetexttable = {}
-f = open(DIALOGUE_TEXT_TABLE, encoding='utf8')
-for line in f:
-    line = line.strip('\n')
-    if not line:
-        continue
-    value, string = tuple(line.split('=', 1))
-    if string not in dialoguetexttable:
-        dialoguetexttable[string] = value
-f.close()
+try:
+    f = open(DIALOGUE_TEXT_TABLE, encoding='utf8')
+    for line in f:
+        line = line.strip('\n')
+        if not line:
+            continue
+        value, string = tuple(line.split('=', 1))
+        if string not in dialoguetexttable:
+            dialoguetexttable[string] = value
+    f.close()
+except FileNotFoundError:
+    print("Error: " + DIALOGUE_TEXT_TABLE + " was not found in the tables folder.")
 
 reverse_dialoguetexttable = {v: k for k, v in dialoguetexttable.items()}
 reverse_dialoguetexttable["1104"] = "<wait 60 frames>"
@@ -291,13 +302,16 @@ def get_long_battle_text_pointer(f, index):
 
 
 battlebg_palettes = {}
-f = open(BATTLE_BG_PALETTE_TABLE)
-for line in f:
-    line = line.strip()
-    bg, palette = tuple(line.split())
-    bg, palette = hex2int(bg), hex2int(palette)
-    battlebg_palettes[bg] = palette
-f.close()
+try:
+    f = open(BATTLE_BG_PALETTE_TABLE)
+    for line in f:
+        line = line.strip()
+        bg, palette = tuple(line.split())
+        bg, palette = hex2int(bg), hex2int(palette)
+        battlebg_palettes[bg] = palette
+    f.close()
+except FileNotFoundError:
+    print("Error: " + BATTLE_BG_PALETTE_TABLE + " was not found in the tables folder.")
 
 
 def int2bytes(value, length=2, reverse=True):

--- a/BeyondChaos/utils.py
+++ b/BeyondChaos/utils.py
@@ -9,6 +9,7 @@ try:
 
     MEI = True
     tblpath = path.join(_MEIPASS, "tables")
+    custom_path = "custom"
 except ImportError:
     # This is new
     # this prepends the absolute file path of the parent/calling script


### PR DESCRIPTION
beyondchaos.py:
- Added more imports from config.py.
- Added menu bar separator and logic to show different update text depending on if there is an update available. It is impossible to style a single menu bar item in PyQt5, unfortunately, so if we want to have an update button with red text, bold text, or any other style, we will have to move the update button from the menu bar and create a standalone button somewhere on the GUI.
- Adjusted the main method to call a validation process. This process validates that required files and folders exist and detects if an update is available from GitHub. 
-- If required files are missing, the user is prompted for a mandatory update to repair the missing files. If the user selects Close, the program closes without starting the GUI.
-- If an update is available, it prompts the users for an optional update. The user can choose not to perform the update by selecting the Close button, after which the GUI will open and a setting will be set to prevent additional pop-ups until an update is performed using the GUI menu button.
- Added exception handling pop-ups. Previously, if an exception occurred, the GUI would close silently. Now a pop-up will occur telling the user what the error is and including a traceback, which can be given to devs.
- Fixed the output directory using the wrong slashes. Just cosmetic.
- When accepting a mandatory update, the core version in config.ini is set as "Error". This will ensure the core update happens to replace missing files, even if the user was previously on the most current version.

config.py:
- Added validate_files(). This method calls all the check_ methods and builds an array of missing files. If any missing files exist, it triggers a mandatory update. If no missing files are found, the method checks all the versions in config.ini against the versions available on GitHub to determine if an update is available to any of the components. If updates are available, it triggers an optional update.
- Added error handling to read_config and changed the method to return a dictionary of version information
- Adjusted get_core_version() and added get_character_sprite_version() and get_monster_sprite_version() to return the specific versions.
- Created check_custom to ensure that the custom directory exists and, inside of it, exist the opera and Sprites directories and a variety of text files.
- Created check_tables to ensure that the tables directory exists and, inside of it, a variety of text files
- Adjusted check_ini() to use the missing_files array
- Adjusted check_remonsterate() to use the missing_files array
- Added are_updates_hidden(), which checks the state of Settings/updates_hidden in config.ini
- Added updates_hidden(bool) to set the value of Settings/updates_hidden in config.ini
- Adjusted method names.
- Removed unused global variables.
- Added set_value and get_value methods to process those operations. Converted a number of other methods to use set_value and get_value.
- Added CONFIG_PATH as a constant variable at the top of the module.

randomizer.py:
- All bcce.cfg lines now use config.ini. bcce.cfg is no longer used.
- Fixed the output directory using the wrong slashes. Just cosmetic.

dialoguemanager.py, locationrandomizer.py, namerandomizer.py, skillrandomizer.py, towerrandomizer.py, utils.py:
- Added error handling for missing files during initialization.

TODO: Add this kind of validation to the console version?

Update [8c09ee3]:
beyondchaos.py:
- Added separate handling for when config.ini is missing, making an assumption that a user is setting up the randomizer for the first time. This handling welcomes the user to the randomizer instead of displaying a list of missing files and folders.
- Converted the QMessageBox contents to use more HTML-like styling.

config.py:
- Disabled tables check, since I forgot that the tables are bundled into the randomizer file itself

utils.py:
- Fixed "NameError: name 'custom_path' is not defined". A recent commit (https://github.com/Crimdahl/BeyondChaosRandomizer/commit/30d78ad56e68634e4ec06df02e49a014b2041109) moved the custom_path definition into a spot where the variable was only defined if an ImportError occurred, causing a crash if the ImportError did not occur.