### PR TITLE
File Validation Adjustments

### DIFF
--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import (QPushButton, QCheckBox, QWidget, QVBoxLayout,
 import utils
 import customthreadpool
 from config import (read_flags, write_flags, validate_files, are_updates_hidden, updates_hidden,
-                    get_input_path, get_output_path, save_version)
+                    get_input_path, get_output_path, save_version, check_player_sprites, check_remonsterate)
 from options import (ALL_FLAGS, NORMAL_CODES, MAKEOVER_MODIFIER_CODES, makeover_groups)
 from update import (get_updater)
 from randomizer import randomize, VERSION, BETA
@@ -583,6 +583,10 @@ class Window(QMainWindow):
                         f"{flagname}  -  {flagdesc['explanation']}",
                         flagname
                     )
+                    if (flagname == "remonsterate" and not len(check_remonsterate()) == 0) or\
+                       (flagname == "makeover" and not len(check_player_sprites()) == 0):
+                        cbox.setEnabled(False)
+
                     self.checkBoxes.append(cbox)
                     tablayout.addWidget(cbox, currentRow, 1, 1, 2)
                     cbox.clicked.connect(lambda checked: self.flagButtonClicked())
@@ -591,7 +595,6 @@ class Window(QMainWindow):
                         nbox = QDoubleSpinBox()
                     else:
                         nbox = QSpinBox()
-
 
                     if flagname == "cursepower":
                         nbox.setMinimum(0)
@@ -820,32 +823,33 @@ class Window(QMainWindow):
         for t in self.tablist:
             children.extend(t.children())
         for child in children:
-            for v in values:
-                v = str(v).lower()
-                if type(child) == FlagCheckBox and v == child.value:
-                    child.setChecked(True)
-                    self.flags.append(v)
-                elif type(child) in [QSpinBox] and str(v).startswith(child.text.lower()):
-                    if ":" in v:
-                        try:
-                            child.setValue(int(str(v).split(":")[1]))
-                            self.flags.append(v)
-                        except ValueError:
-                            pass
-                elif type(child) in [QDoubleSpinBox] and str(v).startswith(child.text.lower()):
-                    if ":" in v:
-                        try:
-                            value = float(str(v).split(":")[1])
-                            if value >= 0:
-                                child.setValue(value)
-                                self.flags.append(v)
-                        except ValueError:
-                            pass
-                elif type(child) in [QComboBox] and str(v).startswith(child.text.lower()):
-                    if ":" in v:
-                        index_of_value = child.findText(str(v).split(":")[1], QtCore.Qt.MatchFixedString)
-                        child.setCurrentIndex(index_of_value)
+            if child.isEnabled():
+                for v in values:
+                    v = str(v).lower()
+                    if type(child) == FlagCheckBox and v == child.value:
+                        child.setChecked(True)
                         self.flags.append(v)
+                    elif type(child) in [QSpinBox] and str(v).startswith(child.text.lower()):
+                        if ":" in v:
+                            try:
+                                child.setValue(int(str(v).split(":")[1]))
+                                self.flags.append(v)
+                            except ValueError:
+                                pass
+                    elif type(child) in [QDoubleSpinBox] and str(v).startswith(child.text.lower()):
+                        if ":" in v:
+                            try:
+                                value = float(str(v).split(":")[1])
+                                if value >= 0:
+                                    child.setValue(value)
+                                    self.flags.append(v)
+                            except ValueError:
+                                pass
+                    elif type(child) in [QComboBox] and str(v).startswith(child.text.lower()):
+                        if ":" in v:
+                            index_of_value = child.findText(str(v).split(":")[1], QtCore.Qt.MatchFixedString)
+                            child.setCurrentIndex(index_of_value)
+                            self.flags.append(v)
         self.updateFlagString()
         self.flagsChanging = False
 

--- a/BeyondChaos/config.py
+++ b/BeyondChaos/config.py
@@ -147,6 +147,29 @@ def check_custom():
     return missing_files
 
 
+def check_player_sprites():
+    missing_files = []
+    custom_directory = Path(os.path.join(os.getcwd(), 'custom'))
+    if not custom_directory.is_dir():
+        missing_files.append('/custom/')
+    else:
+        # List of all files in /custom/. Some of these may not be required or may depend on chosen flags, but better
+        #   safe than sorry
+        required_custom_files = ['spritereplacements.txt']
+        for file in required_custom_files:
+            file_path = Path(os.path.join(custom_directory, file))
+            if not file_path.exists():
+                missing_files.append("/custom/" + file)
+                print("spritereplacements.txt is missing from the Custom directory. The SpriteReplacements category "
+                      "and custom character sprite flags will be unavailable.")
+
+    character_sprites_directory = Path(os.path.join(custom_directory, 'Sprites'))
+    if not character_sprites_directory.is_dir():
+       missing_files.append('/custom/Sprites/')
+
+    return missing_files
+
+
 def check_tables():
     missing_files = []
     if not TABLE_PATH.is_dir():
@@ -192,16 +215,20 @@ def check_remonsterate():
     if os.path.isdir(base_directory):
         if not os.path.isfile(image_file):
             missing_files.append('/remonsterate/images_and_tags')
-            print("The images_and_tags.txt file is missing from the remonsterate directory.")
+            print("The images_and_tags.txt file is missing from the remonsterate directory. The remonsterate flag "
+                  "will be unavailable.")
         if not os.path.isfile(monster_file):
             missing_files.append('/remonsterate/monsters_and_tags.txt')
-            print("The monsters_and_tags.txt file is missing from the remonsterate directory.")
+            print("The monsters_and_tags.txt file is missing from the remonsterate directory. The remonsterate "
+                  "flag will be unavailable.")
         if not os.path.isdir(sprite_directory):
             missing_files.append('/remonsterate/')
-            print("The sprites folder is missing from the remonsterate directory.")
+            print("The sprites folder is missing from the remonsterate directory. The remonsterate flag will be "
+                  "unavailable.")
     else:
         missing_files.append('/remonsterate/')
-        print("The remonsterate folder is missing from the Beyond Chaos directory.")
+        print("The remonsterate folder is missing from the Beyond Chaos directory. The remonsterate flag will be "
+              "unavailable.")
 
     return missing_files
 

--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -353,7 +353,7 @@ try:
                  "spriteCategories", "combobox", ("Normal", "No", "Hate", "Like", "Only"))])
         RESTRICTED_VANILLA_SPRITE_CODES.append(no)
 except FileNotFoundError:
-    print("Error: No spritereplacements.txt found in the custom folder. Spritecategories will be unavailable.")
+    pass
 
 
 # TODO: do this a better way


### PR DESCRIPTION
options.py:
- Removed error message for spritereplacements.txt being missing

config.py:
- Added check_player_sprites() method to check if the files required for custom player sprites exist.
- Adjusted error messages for check_remonsterate()

beyondchaos.py:
- The makeover flag will now be disabled if the required files do not exist for using makeover
- The remonsterate flag will now be disabled if the required files do not existing for using remonsterate
- Flags for disabled GUI controls are now considered invalid and cannot be added to the flagstring. So if makeover or remonsterate are disabled, they cannot be added via manual typing or by selecting presets that contain those flags.