### PR TITLE
GUI Version in Title & Logging Improvements

### DIFF
--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -173,7 +173,7 @@ class Window(QMainWindow):
         super().__init__()
 
         # window geometry data
-        self.title = "Beyond Chaos Randomizer"
+        self.title = "Beyond Chaos Randomizer " + VERSION
         self.left = 200
         self.top = 200
         self.width = 1000


### PR DESCRIPTION
beyondchaos.py:
- Added the randomizer version to the window's title

randomizer.py:
- log_break_learn_items() has been renamed to log_item_mutations(). This method now logs special features, special actions, and elemental properties. This logging is done at the end of the randomization process instead of in the middle of the randomization process as itemrandomizer was doing it previously.
- Logged item mutations are now sorted by item name instead of item ID.
- Command Changers are now found under Item Effects. TODO: Move this logging under log_item_mutations()?

itemrandomizer.py:
- Added deepcopy import.
- Added vanilla_data instance variable for ItemBlock objects.
- When reading the vanilla data from the ROM, when the ItemBlock is created, a duplicate of the ItemBlock is created with deepcopy and stored in the vanilla_data variable, allowing us to easily reference the vanilla state of the item.
- mutation_log and all uses of mutation_log have been removed. All operations handled using mutation_log are now done in log_item_mutations().
- Renamed get_feature() to get_new_feature()
- Added new get_feature() method that will get the name for a feature when passed the type of feature and the feature's byte.
- Using vanilla_data, added some checks to ensure items have been changed before calling mutate_name(). This should prevent most instances of erroneous question marks on names, but until we perform the name mutations completely after item randomization, errors may still occur.
- mutate_name() now supports mutating an items name back to its vanilla value, although this is untested and unused.