### PR TITLE
Combined Code and Flag objects and methods into just Flag.

### DIFF
--- a/BeyondChaos/ancient.py
+++ b/BeyondChaos/ancient.py
@@ -109,10 +109,10 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
     goddess_save_sub.write(fout)
 
     # decrease exp needed for level up
-    if Options_.is_code_active('racecave'):
+    if Options_.is_flag_active('racecave'):
         maxlevel = 49
         divisor = 12.0
-    elif Options_.is_code_active('speedcave'):
+    elif Options_.is_flag_active('speedcave'):
         maxlevel = 49
         divisor = 8.0
     else:
@@ -142,9 +142,9 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
         0x3F, 0x0E, 0x00,
         0x3F, 0x0F, 0x00,
     ])
-    if Options_.is_code_active('racecave'):
+    if Options_.is_flag_active('racecave'):
         num_starting = 9 + random.randint(0, 2) + random.randint(0, 1)
-    elif Options_.is_code_active('speedcave'):
+    elif Options_.is_flag_active('speedcave'):
         num_starting = 4 + random.randint(0, 3) + random.randint(0, 2)
     else:
         num_starting = 4 + random.randint(0, 1) + random.randint(0, 1)
@@ -160,7 +160,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
         fout.seek(cptr)
         level = ord(fout.read(1))
         level &= 0xF3
-        if i >= 14 or Options_.is_code_active("speedcave") and i not in starting:
+        if i >= 14 or Options_.is_flag_active("speedcave") and i not in starting:
             level |= 0b1000
         fout.seek(cptr)
         fout.write(bytes([level]))
@@ -168,7 +168,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
     fout.write(b'\x00')  # remove Terra's magitek
 
     tempcands = [14, 15, random.choice(list(range(18, 28))), random.choice([32, 33])]
-    if Options_.is_code_active('speedcave'):
+    if Options_.is_flag_active('speedcave'):
         tempcands.append(random.choice([16, 17]))
         tempcands.append(random.choice([41, 42, 43]))
     charcands = list(range(14)) + random.sample(tempcands, 2)
@@ -261,7 +261,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
     espers = list(get_espers(sourcefile))
     num_espers = 3
     for i in range(num_espers):
-        if Options_.is_code_active("speedcave"):
+        if Options_.is_flag_active("speedcave"):
             esperrank = 999
         else:
             esperrank = 0
@@ -351,9 +351,9 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
     pilot_sub.set_location(0xC2110)
     pilot_sub.write(fout)
 
-    if Options_.is_code_active("racecave"):
+    if Options_.is_flag_active("racecave"):
         randomize_tower(filename=sourcefile, ancient=True, nummaps=50)
-    elif Options_.is_code_active("speedcave"):
+    elif Options_.is_flag_active("speedcave"):
         randomize_tower(filename=sourcefile, ancient=True, nummaps=85)
     else:
         randomize_tower(filename=sourcefile, ancient=True, nummaps=300)
@@ -390,7 +390,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
         if formation.formid in [0x1a4, 0x1d4, 0x1d5, 0x1d6, 0x1e4,
                                 0x1e2, 0x1ff, 0x1bd, 0x1be]:
             return False
-        if (Options_.is_code_active("racecave")
+        if (Options_.is_flag_active("racecave")
                 and formation.formid in [0x162, 0x1c8, 0x1d3]):
             return False
         return True
@@ -413,7 +413,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
                     and f.get_music() != 0]):
                 return False
         best_drop = formation.get_best_drop()
-        if best_drop and (best_drop.price <= 2 or best_drop.price >= 30000 or Options_.is_code_active("madworld")):
+        if best_drop and (best_drop.price <= 2 or best_drop.price >= 30000 or Options_.is_flag_active("madworld")):
             return True
         return False
 
@@ -450,7 +450,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
             l.write_data(fout)
 
     pointer = 0xB4E35
-    if Options_.is_code_active('racecave'):
+    if Options_.is_flag_active('racecave'):
         candidates = [c for c in starting if c != runaway]
         leaders = random.sample(candidates, 3)
         subptr = pointer - 0xa0000
@@ -531,7 +531,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
               3: (8000, 0xA5F),
               4: (30000, 0xA64)}
 
-    if Options_.is_code_active("racecave"):
+    if Options_.is_flag_active("racecave"):
         partyswitch_template = [
             0x4B, None, None,
             0x4B, 0x86, 0x83,
@@ -647,7 +647,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
     optional_chars = [c for c in characters if hasattr(c, "slotid")]
     optional_chars = [c for c in optional_chars if c.slotid == runaway or
                       (c.id not in starting and c.id in charcands)]
-    if Options_.is_code_active("speedcave"):
+    if Options_.is_flag_active("speedcave"):
         while len(optional_chars) < 24:
             if random.choice([True, True, False]):
                 supplement = [c for c in optional_chars if c.id >= 14 or
@@ -693,7 +693,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
                 allysub.bytestring += [0xD4, 0xF0 | chosen.slotid,
                                        0xD4, 0xE0 | chosen.slotid,
                                        0xD7, mem_addr]
-                if chosen.id >= 14 or Options_.is_code_active("speedcave"):
+                if chosen.id >= 14 or Options_.is_flag_active("speedcave"):
                     allysub.bytestring += [0x77, chosen.slotid,
                                            0x8b, chosen.slotid, 0x7F,
                                            0x8c, chosen.slotid, 0x7F,
@@ -759,7 +759,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
         pointer += innsub.size
         savesub = make_paysub(save_template, save_template2, l, pointer)
         pointer += savesub.size
-        if Options_.is_code_active('racecave'):
+        if Options_.is_flag_active('racecave'):
             pswitch_sub = make_paysub(partyswitch_template,
                                       partyswitch_template2, l, pointer)
             pointer += pswitch_sub.size
@@ -875,7 +875,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
                 setattr(ally, key, value)
             l.npcs.append(ally)
             if (len(optional_chars) == 12 or (optional_chars and
-                                              Options_.is_code_active('speedcave'))):
+                                              Options_.is_flag_active('speedcave'))):
                 temp = optional_chars.pop()
                 if chosen.id != temp.id:
                     chosen = temp
@@ -906,7 +906,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
         for i in range(num_espers):
             if not espers:
                 break
-            if Options_.is_code_active('speedcave'):
+            if Options_.is_flag_active('speedcave'):
                 candidates = espers
             else:
                 esperrank = l.restrank
@@ -956,7 +956,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
             setattr(enemy, key, value)
         l.npcs.append(enemy)
 
-        if Options_.is_code_active('racecave'):
+        if Options_.is_flag_active('racecave'):
             event_addr = (pswitch_sub.location - 0xa0000) & 0x3FFFF
             partyswitch = NPCBlock(pointer=None, locid=l.locid)
             attributes = {
@@ -1044,7 +1044,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
             def enrank(r):
                 mr = min(maxrank, 0xFF)
                 r = max(0, min(r, mr))
-                if Options_.is_code_active('racecave'):
+                if Options_.is_flag_active('racecave'):
                     half = r//2
                     quarter = half//2
                     r = (half + random.randint(0, quarter) +
@@ -1068,12 +1068,12 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
 
             chosen_enemies = sorted(chosen_enemies, key=lambda f: f.rank())
 
-            if Options_.is_code_active('racecave'):
+            if Options_.is_flag_active('racecave'):
                 bossify = False
             elif rank >= maxrank * 0.9:
                 bossify = True
             else:
-                if Options_.is_code_active('speedcave'):
+                if Options_.is_flag_active('speedcave'):
                     thresh = 0.5
                 else:
                     thresh = 0.1
@@ -1089,7 +1089,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
                     chosen_boss = random.choice(candidates)
                     chosen_enemies[3] = chosen_boss
 
-            if Options_.is_code_active('speedcave'):
+            if Options_.is_flag_active('speedcave'):
                 thresh, bossthresh = 2, 1
             else:
                 # allow up to three of the same formation
@@ -1113,7 +1113,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
             fset.write_data(fout)
 
         if not (hasattr(l, "secret_treasure") and l.secret_treasure):
-            if Options_.is_code_active('speedcave') or rank == 0:
+            if Options_.is_flag_active('speedcave') or rank == 0:
                 low = random.randint(0, 400)
                 high = random.randint(low, low*5)
                 high = random.randint(low, high)
@@ -1133,7 +1133,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
                 enemy_limit = None
             l.unlock_chests(int(low), int(high), monster=monster,
                             guarantee_miab_treasure=True,
-                            enemy_limit=enemy_limit, uncapped_monsters=Options_.is_code_active('bsiab'))
+                            enemy_limit=enemy_limit, uncapped_monsters=Options_.is_flag_active('bsiab'))
 
         l.write_data(fout)
 
@@ -1142,7 +1142,7 @@ def manage_ancient(Options_, fout, sourcefile, form_music_overrides=None, randlo
     final_cut.bytestring = bytearray([0x3F, 0x0E, 0x00,
                                       0x3F, 0x0F, 0x00,
                                      ])
-    if not Options_.is_code_active("racecave"):
+    if not Options_.is_flag_active("racecave"):
         final_cut.bytestring += bytearray([0x9D,
                                            0x4D, 0x65, 0x33,
                                            0xB2, 0xA9, 0x5E, 0x00])

--- a/BeyondChaos/appearance.py
+++ b/BeyondChaos/appearance.py
@@ -89,6 +89,7 @@ def recolor_character_palette(fout, pointer, palette=None, flesh=False, middle=T
         outline, eyes, hair, skintone, outfit1, outfit2, NPC = (
             palette[:2], palette[2:4], palette[4:6], palette[6:8],
             palette[8:10], palette[10:12], palette[12:])
+
         def components_to_color(xxx_todo_changeme):
             (red, green, blue) = xxx_todo_changeme
             return red | (green << 5) | (blue << 10)
@@ -114,7 +115,7 @@ def recolor_character_palette(fout, pointer, palette=None, flesh=False, middle=T
 
             if not new_style_palette:
                 new_palette[6:8] = skintone
-            if options.Options_.is_code_active('christmas'):
+            if options.Options_.is_flag_active('christmas'):
                 if santa:
                     # color kefka's palette to make him look santa-ish
                     new_palette = palette
@@ -234,12 +235,12 @@ def manage_coral(fout):
 
 def manage_character_names(fout, change_to, male):
     characters = get_characters()
-    wild = options.Options_.is_code_active('partyparty')
-    sabin_mode = options.Options_.is_code_active('suplexwrecks')
-    tina_mode = options.Options_.is_code_active('bravenudeworld')
-    soldier_mode = options.Options_.is_code_active('quikdraw')
-    moogle_mode = options.Options_.is_code_active('kupokupo')
-    ghost_mode = options.Options_.is_code_active('halloween')
+    wild = options.Options_.is_flag_active('partyparty')
+    sabin_mode = options.Options_.is_flag_active('suplexwrecks')
+    tina_mode = options.Options_.is_flag_active('bravenudeworld')
+    soldier_mode = options.Options_.is_flag_active('quikdraw')
+    moogle_mode = options.Options_.is_flag_active('kupokupo')
+    ghost_mode = options.Options_.is_flag_active('halloween')
 
     names = []
     if tina_mode:
@@ -321,7 +322,7 @@ def manage_character_names(fout, change_to, male):
         from monsterrandomizer import change_enemy_name
         change_enemy_name(fout, umaro_id, umaro_name)
 
-    if not options.Options_.is_code_active('capslockoff'):
+    if not options.Options_.is_flag_active('capslockoff'):
         names = [name.upper() for name in names]
 
     for c in characters:
@@ -338,8 +339,8 @@ def manage_character_names(fout, change_to, male):
 
 def get_free_portrait_ids(swap_to, change_to, char_ids, char_portraits):
     # get unused portraits so we can overwrite them if needed
-    sprite_swap_mode = options.Options_.is_code_active('makeover')
-    wild = options.Options_.is_code_active('partyparty')
+    sprite_swap_mode = options.Options_.is_flag_active('makeover')
+    wild = options.Options_.is_flag_active('partyparty')
     if not sprite_swap_mode:
         return [], False
 
@@ -386,11 +387,11 @@ def get_free_portrait_ids(swap_to, change_to, char_ids, char_portraits):
 
 
 def get_sprite_swaps(char_ids, male, female, vswaps):
-    sprite_swap_mode = options.Options_.is_code_active('makeover')
-    wild = options.Options_.is_code_active('partyparty')
-    clone_mode = options.Options_.is_code_active('cloneparty')
-    replace_all = options.Options_.is_code_active('novanilla') or options.Options_.is_code_active('frenchvanilla')
-    external_vanillas = False if options.Options_.is_code_active('novanilla') else (options.Options_.is_code_active('frenchvanilla') or clone_mode)
+    sprite_swap_mode = options.Options_.is_flag_active('makeover')
+    wild = options.Options_.is_flag_active('partyparty')
+    clone_mode = options.Options_.is_flag_active('cloneparty')
+    replace_all = options.Options_.is_flag_active('novanilla') or options.Options_.is_flag_active('frenchvanilla')
+    external_vanillas = False if options.Options_.is_flag_active('novanilla') else (options.Options_.is_flag_active('frenchvanilla') or clone_mode)
     if not sprite_swap_mode:
         return []
 
@@ -447,7 +448,7 @@ def get_sprite_swaps(char_ids, male, female, vswaps):
         known_replacements.extend(og_replacements)
 
     # weight selection based on no*/hate*/like*/only* codes
-    whitelist = [c for c in options.Options_.active_codes.keys() if options.Options_.get_code_value(c) == "only"]
+    whitelist = [c for c in options.Options_.active_flags.keys() if options.Options_.get_flag_value(c) == "only"]
     replace_candidates = []
     for r in known_replacements:
         whitelisted = False
@@ -456,11 +457,11 @@ def get_sprite_swaps(char_ids, male, female, vswaps):
                 break
             if g in whitelist:
                 whitelisted = True
-            if options.Options_.get_code_value(g) == "no":
+            if options.Options_.get_flag_value(g) == "no":
                 r.weight = 0
-            elif options.Options_.get_code_value(g) == "hate":
+            elif options.Options_.get_flag_value(g) == "hate":
                 r.weight /= 3
-            elif options.Options_.get_code_value(g) == "like":
+            elif options.Options_.get_flag_value(g) == "like":
                 r.weight *= 2
         if whitelist and not whitelisted:
             r.weight = 0
@@ -510,15 +511,15 @@ def get_sprite_swaps(char_ids, male, female, vswaps):
 
 def manage_character_appearance(fout, preserve_graphics=False):
     characters = get_characters()
-    wild = options.Options_.is_code_active('partyparty')
-    sabin_mode = options.Options_.is_code_active('suplexwrecks')
-    tina_mode = options.Options_.is_code_active('bravenudeworld')
-    soldier_mode = options.Options_.is_code_active('quikdraw')
-    moogle_mode = options.Options_.is_code_active('kupokupo')
-    ghost_mode = options.Options_.is_code_active('halloween')
-    christmas_mode = options.Options_.is_code_active('christmas')
-    sprite_swap_mode = options.Options_.is_code_active('makeover') and not (sabin_mode or tina_mode or soldier_mode or moogle_mode or ghost_mode)
-    new_palette_mode = not options.Options_.is_code_active('sometimeszombies')
+    wild = options.Options_.is_flag_active('partyparty')
+    sabin_mode = options.Options_.is_flag_active('suplexwrecks')
+    tina_mode = options.Options_.is_flag_active('bravenudeworld')
+    soldier_mode = options.Options_.is_flag_active('quikdraw')
+    moogle_mode = options.Options_.is_flag_active('kupokupo')
+    ghost_mode = options.Options_.is_flag_active('halloween')
+    christmas_mode = options.Options_.is_flag_active('christmas')
+    sprite_swap_mode = options.Options_.is_flag_active('makeover') and not (sabin_mode or tina_mode or soldier_mode or moogle_mode or ghost_mode)
+    new_palette_mode = not options.Options_.is_flag_active('sometimeszombies')
 
     sprite_log = ""
 
@@ -764,10 +765,10 @@ def manage_character_appearance(fout, preserve_graphics=False):
 
 
 def manage_palettes(fout, change_to, char_ids):
-    sabin_mode = options.Options_.is_code_active('suplexwrecks')
-    tina_mode = options.Options_.is_code_active('bravenudeworld')
-    christmas_mode = options.Options_.is_code_active('christmas')
-    new_palette_mode = not options.Options_.is_code_active('sometimeszombies')
+    sabin_mode = options.Options_.is_flag_active('suplexwrecks')
+    tina_mode = options.Options_.is_flag_active('bravenudeworld')
+    christmas_mode = options.Options_.is_flag_active('christmas')
+    new_palette_mode = not options.Options_.is_flag_active('sometimeszombies')
 
     from locationrandomizer import get_npcs
     characters = get_characters()
@@ -855,7 +856,7 @@ def manage_palettes(fout, change_to, char_ids):
                 fout.write(bytes([byte]))
         character.palette = new_palette
 
-    if options.Options_.is_code_active('repairpalette'):
+    if options.Options_.is_flag_active('repairpalette'):
         make_palette_repair(fout, main_palette_changes)
 
     if new_palette_mode:
@@ -925,9 +926,9 @@ def manage_palettes(fout, change_to, char_ids):
             continue
         line = line.split(' ')
         if len(line) > 1:
-            if line[1] == 'c' and options.Options_.is_code_active('thescenarionottaken'):
+            if line[1] == 'c' and options.Options_.is_flag_active('thescenarionottaken'):
                 return
-            if line[1] == 'd' and not options.Options_.is_code_active('thescenarionottaken'):
+            if line[1] == 'd' and not options.Options_.is_flag_active('thescenarionottaken'):
                 return
         pointer = hex2int(line[0].strip())
         fout.seek(pointer)

--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -24,7 +24,7 @@ import utils
 import customthreadpool
 from config import (read_flags, write_flags, validate_files, are_updates_hidden, updates_hidden,
                     get_input_path, get_output_path, save_version, check_player_sprites, check_remonsterate)
-from options import (NORMAL_CODES, MAKEOVER_MODIFIER_CODES, get_makeover_groups)
+from options import (NORMAL_FLAGS, MAKEOVER_MODIFIER_FLAGS, get_makeover_groups)
 from update import (get_updater)
 from randomizer import randomize, VERSION, BETA, MD5HASHNORMAL, MD5HASHTEXTLESS, MD5HASHTEXTLESS2
 
@@ -277,7 +277,7 @@ class Window(QMainWindow):
 
         # Begin buiding program/window
         # pull data from files
-        self.initCodes()
+        self.initFlags()
 
         # create window using geometry data
         self.initWindow()
@@ -903,30 +903,30 @@ class Window(QMainWindow):
 
     # (At startup) Opens reads code flags/descriptions and
     #   puts data into separate dictionaries
-    def initCodes(self):
-        for code in NORMAL_CODES + MAKEOVER_MODIFIER_CODES:
-            if code.category == "flags":
+    def initFlags(self):
+        for flag in NORMAL_FLAGS + MAKEOVER_MODIFIER_FLAGS:
+            if flag.category == "flags":
                 d = self.flag
-            elif code.category == "aesthetic":
+            elif flag.category == "aesthetic":
                 d = self.aesthetic
-            elif code.category == "sprite":
+            elif flag.category == "sprite":
                 d = self.sprite
-            elif code.category == "spriteCategories":
+            elif flag.category == "spriteCategories":
                 d = self.spriteCategories
-            elif code.category == "experimental":
+            elif flag.category == "experimental":
                 d = self.experimental
-            elif code.category == "gamebreaking":
+            elif flag.category == "gamebreaking":
                 d = self.gamebreaking
-            elif code.category == "field":
+            elif flag.category == "field":
                 d = self.field
-            elif code.category == "characters":
+            elif flag.category == "characters":
                 d = self.characters
-            elif code.category == "beta":
+            elif flag.category == "beta":
                 d = self.beta
-            elif code.category == "battle":
+            elif flag.category == "battle":
                 d = self.battle
             else:
-                print(f"Code {code.name} does not have a valid category.")
+                print(f"Flag {flag.name} does not have a valid category.")
                 continue
 
             # d[code.name] = {
@@ -935,9 +935,9 @@ class Window(QMainWindow):
             #     'checked': False,
             #     'choices': code.choices
             # }
-            d[code.name] = {
+            d[flag.name] = {
                 'checked': False,
-                'object': code
+                'object': flag
             }
 
         # for flag in sorted(ALL_FLAGS):
@@ -1078,7 +1078,7 @@ class Window(QMainWindow):
 
         self.modeBox.setCurrentIndex(0)
         self.presetBox.setCurrentIndex(0)
-        self.initCodes()
+        self.initFlags()
         self.updateFlagCheckboxes()
         self.flagButtonClicked()
         self.flagString.clear()
@@ -1301,7 +1301,7 @@ class Window(QMainWindow):
                 QMessageBox.about(
                     self,
                     "Error",
-                    "You need to select a flag and/or code!"
+                    "You need to select a flag!"
                 )
                 return
 

--- a/BeyondChaos/itemrandomizer.py
+++ b/BeyondChaos/itemrandomizer.py
@@ -772,7 +772,7 @@ class ItemBlock:
         if vanilla:
             self.name = self.vanilla_data.name
             self.dataname[1:] = name_to_bytes(self.name, len(self.name))
-        elif options.Options_.is_code_active("questionablecontent") and not self.is_consumable and '?' not in self.name:
+        elif options.Options_.is_flag_active("questionablecontent") and not self.is_consumable and '?' not in self.name:
             self.name = self.name[:11] + '?'
             # Index on self.dataname is [1:] because the first character determines the
             #   equipment symbol (helmet/shield/etc).

--- a/BeyondChaos/monsterrandomizer.py
+++ b/BeyondChaos/monsterrandomizer.py
@@ -754,8 +754,8 @@ class MonsterBlock:
         self.stats['mp'] = int(round(max(self.stats['mp'], factor * max(s.mp for s in skillset))))
 
     def mutate_ai(self, Options_, change_skillset=True, safe_solo_terra=True):
-        itembreaker = Options_.is_code_active("collateraldamage")
-        if self.name[:2] == "L." and not Options_.is_code_active("randombosses"):
+        itembreaker = Options_.is_flag_active("collateraldamage")
+        if self.name[:2] == "L." and not Options_.is_flag_active("randombosses"):
             change_skillset = False
         elif "guardian" in self.name.lower():
             return
@@ -771,11 +771,11 @@ class MonsterBlock:
             f = s1.abort_on_allies == s2.abort_on_allies
             return a and b and c and d and e and f
 
-        if Options_.mode.name == "katn" or Options_.is_code_active("madworld"):
+        if Options_.mode.name == "katn" or Options_.is_flag_active("madworld"):
             restricted = [0xEA, 0xC8] #restrict Baba Breath and Seize
         else:
             restricted = [0x13, 0x14] #restrict Meteor and Ultima for normal playthroughs
-        if Options_.is_code_active("darkworld"):
+        if Options_.is_flag_active("darkworld"):
             restricted = []  # All skills are fair game sucka
 
         banned = restricted
@@ -1684,9 +1684,9 @@ class MonsterBlock:
         self.special = special
 
     def mutate(self, Options_, change_skillset=None, safe_solo_terra=True, katn=False):
-        randombosses = Options_.is_code_active("randombosses")
-        darkworld = Options_.is_code_active("darkworld")
-        madworld = Options_.is_code_active("madworld")
+        randombosses = Options_.is_flag_active("randombosses")
+        darkworld = Options_.is_flag_active("darkworld")
+        madworld = Options_.is_flag_active("madworld")
 
         if change_skillset is None:
             change_skillset = randombosses or not (self.is_boss or self.boss_death)

--- a/BeyondChaos/musicinterface.py
+++ b/BeyondChaos/musicinterface.py
@@ -26,11 +26,11 @@ def music_init():
     
 def randomize_music(fout, Options_, opera=None, form_music_overrides={}):
     events = ""
-    if Options_.is_code_active('christmas'):
+    if Options_.is_flag_active('christmas'):
         events += "W"
-    if Options_.is_code_active('halloween'):
+    if Options_.is_flag_active('halloween'):
         events += "H"
-    f_chaos = Options_.is_code_active('johnnyachaotic')
+    f_chaos = Options_.is_flag_active('johnnyachaotic')
 
     kan_mode = Options_.mode.name == 'katn'
 
@@ -40,7 +40,7 @@ def randomize_music(fout, Options_, opera=None, form_music_overrides={}):
     ## For anyone who wants to add UI for playlist selection:
     ## If a playlist is selected, pass it as process_music(playlist_filename=...)
     data = process_music(data, metadata, f_chaos=f_chaos, eventmodes=events, opera=opera, subpath="music", freespace=BC_MUSIC_FREESPACE, ext_rng=random)
-    if not Options_.is_any_code_active(['ancientcave', 'speedcave', 'racecave']):
+    if not Options_.is_any_flag_active(['ancientcave', 'speedcave', 'racecave']):
         data = process_map_music(data)
     data = process_formation_music_by_table(data, form_music_overrides=form_music_overrides, kan_mode=kan_mode)
     

--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -7,89 +7,63 @@ from typing import List, Set, Union
 class Mode:
     name: str
     description: str
-    forced_codes: List[str] = field(default_factory=list)
-    prohibited_codes: List[str] = field(default_factory=list)
+    forced_flags: List[str] = field(default_factory=list)
+    # prohibited_codes: List[str] = field(default_factory=list)
     prohibited_flags: Set[str] = field(default_factory=set)
 
 
-@dataclass(order=True, frozen=True)
+@dataclass(unsafe_hash=True)
 class Flag:
-    name: str
-    attr: str
-    description: str
-    inputtype: str
-
-    def __post_init__(self):
-        object.__setattr__(self, 'name', self.name[0])
-
-
-@dataclass(frozen=True)
-class Code:
-    name: str
-    description: str
-    long_description: str
-    category: str
-    inputtype: str
-    key1: str = ''
-    key2: str = ''
-    choices: [str] = field(default_factory=list)
-    default_index: int = 0
-    default_value: str = ""
-    minimum_value: int = 0
-    maximum_value: int = 255
+    name: str = field(default="")
+    description: str = field(default="", compare=False)
+    long_description: str = field(default="", compare=False)
+    category: str = field(default="", compare=False)
+    inputtype: str = field(default="", compare=False)
+    choices: [str] = field(default_factory=list, compare=False)
+    default_index: int = field(default=0, compare=False)
+    default_value: str = field(default="", compare=False)
+    minimum_value: int = field(default=0, compare=False)
+    maximum_value: int = field(default=255, compare=False)
 
     def remove_from_string(self, flag_string: str, mode: Mode):
         name = self.name
         invert_simple_flags = flag_string.startswith("-")
 
-        if name in flag_string:
-            if name in mode.prohibited_flags or name in mode.prohibited_codes:
-                # The code is prohibited. Notify the user and remove it from the flagstring without activating it.
-                print("The code " + name + " has been deactivated. It is incompatible with " + mode.name + ".")
+        # Search for a match for the flag ending in a colon. If a match is found, it's a flag that
+        #     has a value, like swdtechspeed
+        if re.search(r'\b' + re.escape(name) + r":", flag_string):
+            string_after_key = flag_string[flag_string.index(name + ":") + len(name + ":"):]
+            try:
+                value = string_after_key[:string_after_key.index(" ")]
+            except ValueError:
+                # A space did not exist after the flag. Get the entire rest of the flag string.
+                value = string_after_key
+
+            return True, value, re.sub(r'\b' + re.escape(name) + r':' + re.escape(value) + r'\b',
+                                       '',
+                                       flag_string,
+                                       re.IGNORECASE)
+
+        # Search for a match for the flag ending in a word boundary. If a match is found, it's a flag that
+        #     is on/off.
+        elif re.search(r'\b' + re.escape(name) + r"\b", flag_string):
+            if len(name) == 1 and invert_simple_flags:
                 return False, False, re.sub(r'\b' + re.escape(name) + r'\b',
                                             '',
                                             flag_string,
                                             re.IGNORECASE)
-            # Search for a match starting with a word boundary, then the flag name, then :
-            if re.search(r'\b' + re.escape(name) + r":", flag_string):
-                # If the code has a colon after it, we need to get a value
-                string_after_key = flag_string[flag_string.index(name + ":") + len(name + ":"):]
-                try:
-                    value = string_after_key[:string_after_key.index(" ")]
-                except ValueError:
-                    # A space did not exist after the flag. Get the entire rest of the flag string.
-                    value = string_after_key
-
-                return True, value, re.sub(r'\b' + re.escape(name) + r':' + re.escape(value) + r'\b',
-                                           '',
-                                           flag_string,
-                                           re.IGNORECASE)
-
-            # Search for a match starting with a word boundary, then the flag name, then another word boundary
-            elif re.search(r'\b' + re.escape(name) + r"\b", flag_string):
-                if len(name) == 1 and invert_simple_flags:
-                    # If the code is a simple flag and we have the dash inverting the codes,
-                    #     remove it instead of add it.
-                    return False, False, re.sub(r'\b' + re.escape(name) + r'\b',
-                                                '',
-                                                flag_string,
-                                                re.IGNORECASE)
-                else:
-                    # The code being activated has no specific value. Return True.
-                    return True, True, re.sub(r'\b' + re.escape(name) + r'\b',
-                                              '',
-                                              flag_string,
-                                              re.IGNORECASE)
-        else:
-            # The code was not found in the flag string. The only thing we have to worry about here is if
-            #    the flagstring starts with a dash. If it does, we need to activate all of the simple flags
-            #    that weren't found in the flagstring, except if they are prohibited.
-            if len(name) == 1 and invert_simple_flags and not \
-                    (name in mode.prohibited_flags or name in mode.prohibited_codes):
+            else:
                 return True, True, re.sub(r'\b' + re.escape(name) + r'\b',
                                           '',
                                           flag_string,
                                           re.IGNORECASE)
+
+        # The flag was not found. Is it a simple flag and needs to be turned on?
+        if len(name) == 1 and invert_simple_flags:
+            return True, True, re.sub(r'\b' + re.escape(name) + r'\b',
+                                      '',
+                                      flag_string,
+                                      re.IGNORECASE)
 
         return False, False, flag_string
 
@@ -97,8 +71,7 @@ class Code:
 @dataclass
 class Options:
     mode: Mode
-    active_codes = {}
-    active_flags: Set[Flag] = field(default_factory=set)
+    active_flags = {}
     shuffle_commands: bool = field(init=False, default=False)
     replace_commands: bool = field(init=False, default=False)
     sprint: bool = field(init=False, default=False)
@@ -123,119 +96,78 @@ class Options:
     randomize_magicite: bool = field(init=False, default=False)
     random_final_party: bool = field(init=False, default=False)
 
-    def is_code_active(self, code_name: str):
-        if code_name in self.active_codes.keys():
+    def is_flag_active(self, flag_name: str):
+        if flag_name in self.active_flags.keys():
             return True
-        # for code in self.active_codes:
-        #    if code.name == code_name:
-        #        return True
         return False
 
-    def is_any_code_active(self, code_names: List[str]):
-        for code in code_names:
-            if code in self.active_codes.keys():
+    def is_any_flag_active(self, flag_names: List[str]):
+        for flag in flag_names:
+            if flag in self.active_flags.keys():
                 return True
-        # for code in self.active_codes:
-        #    if code.name in code_names:
-        #        return True
         return False
 
-    def get_code_value(self, code_name: str):
+    def get_flag_value(self, flag_name: str):
         try:
-            return self.active_codes[code_name]
+            return self.active_flags[flag_name]
         except KeyError:
             return None
 
-    # Commented out because it was unused
-    # def is_flag_active(self, flag_name: str):
-    #     for flag in self.active_flags:
-    #         if flag.name == flag_name:
-    #             return True
-    #     return False
-
-    def activate_code(self, code_name: str, code_value=None):
-        for code in ALL_CODES:
-            if code.name == code_name:
-                self.active_codes[code_name] = code_value
-                if code in MAKEOVER_MODIFIER_CODES:
-                    self.activate_code("makeover")
-                if code in RESTRICTED_VANILLA_SPRITE_CODES:
-                    self.activate_code("frenchvanilla")
+    def activate_flag(self, flag_name: str, flag_value=None):
+        for flag in ALL_FLAGS:
+            if flag.name == flag_name:
+                self.active_flags[flag_name] = flag_value
+                if flag in MAKEOVER_MODIFIER_FLAGS:
+                    self.activate_flag("makeover")
+                if flag in RESTRICTED_VANILLA_SPRITE_FLAGS:
+                    self.activate_flag("frenchvanilla")
                 return
 
-    # Commented out because it was unused
-    # def activate_flag(self, flag: Flag):
-    #     self.active_flags.add(flag)
-    #     setattr(self, flag.description, True)
-
     def activate_from_string(self, flag_string):
-        for code in self.mode.forced_codes:
-            self.activate_code(code)
-
         s = ""
-        #flags, codes = read_Options_from_string(flag_string, self.mode)
-        codes = read_Options_from_string(flag_string, self.mode)
-        for code, value in codes.items():
-            if code == 'sketch' and ('sketch' in codes.keys() and 'remonsterate' in codes.keys()):
-                s += f"SECRET CODE: 'sketch' is not compatible with remonsterate code.\n"
+        flags = read_Options_from_string(flag_string, self.mode)
+
+        for flag in flags:
+            # Detect incompatible and prohibited flags
+            if flag.name in self.mode.prohibited_flags:
+                # The flag is prohibited. Notify the user and do not activate it.
+                print("The flag '" + flag.name + "' has been deactivated. It is incompatible with " +
+                      self.mode.name + ".")
                 continue
-            for code_object in NORMAL_CODES + MAKEOVER_MODIFIER_CODES:
-                if code_object.name == code and len(code_object.name) > 1:
-                    if code_object.category == "spriteCategories":
-                        s += f"SECRET CODE: {str(value).upper()} {str(code).upper()} MODE ACTIVATED\n"
-                    else:
-                        s += f"SECRET CODE: {code_object.description} ACTIVATED\n"
-            self.activate_code(code, codes[code])
+            if flag.name == 'sketch' and [f for f in flags if f.name == 'remonsterate']:
+                print("The flag '" + flag.name + "' has been deactivated. It is incompatible with remonsterate.")
+                continue
 
-        if self.is_code_active('strangejourney'):
-            self.activate_code('notawaiter')
+            if len(flag.name) > 1:
+                if not flag.category == 'spriteCategories':
+                    s += f"SECRET CODE: {flag.description} ACTIVATED\n"
+                else:
+                    s += f"SECRET CODE: {str(flag.value).upper()} {str(flag.name).upper()} MODE ACTIVATED\n"
+            self.activate_flag(flag.name, flag.value)
 
-        # flags -= self.mode.prohibited_flags
-        # if not flags:
-        #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f not in self.mode.prohibited_flags}
-        #
-        # for flag in flags:
-        #     self.activate_flag(flag)
+        for flag in [f for f in self.mode.forced_flags if not self.is_flag_active(f)]:
+            self.activate_flag(flag)
+        if self.is_flag_active('strangejourney'):
+            self.activate_flag('notawaiter')
 
         return s
 
 
 def read_Options_from_string(flag_string: str, mode: Union[Mode, str]):
-    # flags = set()
-    codes = {}
+    flags = set()
 
     if isinstance(mode, str):
         mode = [m for m in ALL_MODES if m.name == mode][0]
 
-    for code in NORMAL_CODES + MAKEOVER_MODIFIER_CODES:
+    for flag in NORMAL_FLAGS + MAKEOVER_MODIFIER_FLAGS:
         if len(flag_string) == 0:
             break
-        found, value, flag_string = code.remove_from_string(flag_string, mode)
+        found, value, flag_string = flag.remove_from_string(flag_string, mode)
         if found:
-            codes[code.name] = value
-    # if '-' in flag_string:
-    #     print("NOTE: Using all flags EXCEPT the specified flags.")
-    #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f.name not in flag_string}
-    # else:
-    #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f.name in flag_string}
-    #
-    # flags -= mode.prohibited_flags
-    # if not flags:
-    #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f not in mode.prohibited_flags}
+            flag.value = value
+            flags.add(flag)
 
-    # return flags, codes
-    return codes
-
-
-ANCIENT_CAVE_PROHIBITED_CODES = [
-    "airship",
-    "alasdraco",
-    "notawaiter",
-    "strangejourney",
-    "worringtriad",
-    "thescenarionottaken",
-    "mimetime"
-]
+    return flags
 
 
 ANCIENT_CAVE_PROHIBITED_FLAGS = {
@@ -243,324 +175,232 @@ ANCIENT_CAVE_PROHIBITED_FLAGS = {
     "k",
     "r",
     "j",
+    "airship",
+    "alasdraco",
+    "notawaiter",
+    "strangejourney",
+    "worringtriad",
+    "thescenarionottaken",
+    "mimetime"
 }
 
 ALL_MODES = [
     Mode(name="normal", description="Play through the normal story."),
     Mode(name="ancientcave",
          description="Play through a long randomized dungeon.",
-         forced_codes=["ancientcave"],
-         prohibited_codes=ANCIENT_CAVE_PROHIBITED_CODES,
+         forced_flags=["ancientcave"],
          prohibited_flags=ANCIENT_CAVE_PROHIBITED_FLAGS),
     Mode(name="speedcave",
          description="Play through a medium-sized randomized dungeon.",
-         forced_codes=["speedcave", "ancientcave"],
-         prohibited_codes=ANCIENT_CAVE_PROHIBITED_CODES,
+         forced_flags=["speedcave", "ancientcave"],
          prohibited_flags=ANCIENT_CAVE_PROHIBITED_FLAGS),
     Mode(name="racecave",
          description="Play through a short randomized dungeon.",
-         forced_codes=["racecave", "speedcave", "ancientcave"],
-         prohibited_codes=ANCIENT_CAVE_PROHIBITED_CODES,
+         forced_flags=["racecave", "speedcave", "ancientcave"],
          prohibited_flags=ANCIENT_CAVE_PROHIBITED_FLAGS),
     Mode(name="katn",
          description="Play the normal story up to Kefka at Narshe. Intended for racing.",
-         prohibited_codes=["airship", "alasdraco", "worringtriad", "mimetime"],
-         prohibited_flags={"d", "k", "r"}),
+         prohibited_flags={"d", "k", "r", "airship", "alasdraco", "worringtriad", "mimetime"}),
     # Static number of encounters on Lete River, No charm drops, Start with random Espers,
     # Curated enemy specials, Banned Baba Breath & Seize
     Mode(name="dragonhunt",
          description="Kill all 8 dragons in the World of Ruin. Intended for racing.",
-         forced_codes=["worringtriad"],
-         prohibited_codes=["airship", "alasdraco", "thescenarionottaken"],
-         prohibited_flags={"j"}),
+         forced_flags=["worringtriad"],
+         prohibited_flags={"j", "airship", "alasdraco", "thescenarionottaken"}),
 ]
 
-# ALL_FLAGS = [
-#     Flag(name='b',
-#          description='fix_exploits',
-#          long_description='Make the game more balanced by removing known exploits.',
-#          inputtype="checkbox"),
-#     Flag(name='c',
-#          description='random_palettes_and_names',
-#          long_description='Randomize palettes and names of various things.',
-#          inputtype="checkbox"),
-#     Flag(name='d',
-#          description='random_final_dungeon',
-#          long_description='Randomize final dungeon.',
-#          inputtype="checkbox"),
-#     Flag(name='e',
-#          description='random_espers',
-#          long_description='Randomize esper spells and levelup bonuses.',
-#          inputtype="checkbox"),
-#     Flag(name='f',
-#          description='random_formations',
-#          long_description='Randomize enemy formations.',
-#          inputtype="checkbox"),
-#     Flag(name='g',
-#          description='random_dances',
-#          long_description='Randomize dances.',
-#          inputtype="checkbox"),
-#     Flag(name='h',
-#          description='random_final_party',
-#          long_description='Your party in the Final Kefka fight will be random.',
-#          inputtype="checkbox"),
-#     Flag(name='i',
-#          description='random_items',
-#          long_description='Randomize the stats of equippable items.',
-#          inputtype="checkbox"),
-#     Flag(name='j',
-#          description='randomize_forest',
-#          long_description='Randomize the phantom forest.',
-#          inputtype="checkbox"),
-#     Flag(name='k',
-#          description='random_clock',
-#          long_description='Randomize the clock in Zozo.',
-#          inputtype="checkbox"),
-#     Flag(name='l',
-#          description='random_blitz',
-#          long_description='Randomize blitz inputs.',
-#          inputtype="checkbox"),
-#     Flag(name='m',
-#          description='random_enemy_stats',
-#          long_description='Randomize enemy stats.',
-#          inputtype="checkbox"),
-#     Flag(name='n',
-#          description='random_window',
-#          long_description='Randomize window background colors.',
-#          inputtype="checkbox"),
-#     Flag(name='o',
-#          description='shuffle_commands',
-#          long_description="Shuffle characters' in-battle commands.",
-#          inputtype="checkbox"),
-#     Flag(name='p',
-#          description='random_animation_palettes',
-#          long_description='Randomize the palettes of spells and weapon animations.',
-#          inputtype="checkbox"),
-#     Flag(name='q',
-#          description='random_character_stats',
-#          long_description='Randomize what equipment each character can wear and character stats.',
-#          inputtype="checkbox"),
-#     Flag(name='r',
-#          description='shuffle_wor',
-#          long_description='Randomize character locations in the world of ruin.',
-#          inputtype="checkbox"),
-#     Flag(name='s',
-#          description='swap_sprites',
-#          long_description='Swap character graphics around.',
-#          inputtype="checkbox"),
-#     Flag(name='t',
-#          description='random_treasure',
-#          long_description='Randomize treasure including chests, colosseum, shops, and enemy drops.',
-#          inputtype="checkbox"),
-#     Flag(name='u',
-#          description='random_zerker',
-#          long_description='Umaro risk. (Random character will be berserk)',
-#          inputtype="checkbox"),
-#     Flag(name='w',
-#          description='replace_commands',
-#          long_description='Generate new commands for characters,replacing old commands.',
-#          inputtype="checkbox"),
-#     Flag(name='y',
-#          description='randomize_magicite',
-#          long_description='Shuffle magicite locations.',
-#          inputtype="checkbox"),
-#     Flag(name='z',
-#          description='sprint',
-#          long_description='Always have "Sprint Shoes" effect.',
-#          inputtype="checkbox"),
-# ]
 
-NORMAL_CODES = [
+NORMAL_FLAGS = [
     # Flags
-    Code(name='b',
+    Flag(name='b',
          description='fix_exploits',
          long_description='Make the game more balanced by removing known exploits.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='c',
+    Flag(name='c',
          description='random_palettes_and_names',
          long_description='Randomize palettes and names of various things.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='d',
+    Flag(name='d',
          description='random_final_dungeon',
          long_description='Randomize final dungeon.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='e',
+    Flag(name='e',
          description='random_espers',
          long_description='Randomize esper spells and levelup bonuses.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='f',
+    Flag(name='f',
          description='random_formations',
          long_description='Randomize enemy formations.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='g',
+    Flag(name='g',
          description='random_dances',
          long_description='Randomize dances.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='h',
+    Flag(name='h',
          description='random_final_party',
          long_description='Your party in the Final Kefka fight will be random.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='i',
+    Flag(name='i',
          description='random_items',
          long_description='Randomize the stats of equippable items.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='j',
+    Flag(name='j',
          description='randomize_forest',
          long_description='Randomize the phantom forest.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='k',
+    Flag(name='k',
          description='random_clock',
          long_description='Randomize the clock in Zozo.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='l',
+    Flag(name='l',
          description='random_blitz',
          long_description='Randomize blitz inputs.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='m',
+    Flag(name='m',
          description='random_enemy_stats',
          long_description='Randomize enemy stats.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='n',
+    Flag(name='n',
          description='random_window',
          long_description='Randomize window background colors.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='o',
+    Flag(name='o',
          description='shuffle_commands',
          long_description="Shuffle characters' in-battle commands.",
          category="flags",
          inputtype="checkbox"),
-    Code(name='p',
+    Flag(name='p',
          description='random_animation_palettes',
          long_description='Randomize the palettes of spells and weapon animations.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='q',
+    Flag(name='q',
          description='random_character_stats',
          long_description='Randomize what equipment each character can wear and character stats.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='r',
+    Flag(name='r',
          description='shuffle_wor',
          long_description='Randomize character locations in the world of ruin.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='s',
+    Flag(name='s',
          description='swap_sprites',
          long_description='Swap character graphics around.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='t',
+    Flag(name='t',
          description='random_treasure',
          long_description='Randomize treasure including chests, colosseum, shops, and enemy drops.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='u',
+    Flag(name='u',
          description='random_zerker',
          long_description='Umaro risk. (Random character will be berserk)',
          category="flags",
          inputtype="checkbox"),
-    Code(name='w',
+    Flag(name='w',
          description='replace_commands',
          long_description='Generate new commands for characters,replacing old commands.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='y',
+    Flag(name='y',
          description='randomize_magicite',
          long_description='Shuffle magicite locations.',
          category="flags",
          inputtype="checkbox"),
-    Code(name='z',
+    Flag(name='z',
          description='sprint',
          long_description='Always have "Sprint Shoes" effect.',
          category="flags",
          inputtype="checkbox"),
 
     # Sprite codes
-    Code(name='bravenudeworld',
+    Flag(name='bravenudeworld',
          description="TINA PARTY MODE",
          long_description="All characters use the Esper Terra sprite.",
          category="sprite",
          inputtype="checkbox"),
-    Code(name='makeover',
+    Flag(name='makeover',
          description="SPRITE REPLACEMENT MODE",
          long_description="Some sprites are replaced with new ones (like Cecil or Zero Suit Samus).",
          category="sprite",
          inputtype="checkbox"),
-    Code(name='kupokupo',
+    Flag(name='kupokupo',
          description="MOOGLE MODE",
          long_description="All party members are moogles except Mog. With partyparty, "
                           "all characters are moogles, except Mog, Esper Terra, and Imps.",
          category="sprite",
          inputtype="checkbox"),
-    Code(name='partyparty',
+    Flag(name='partyparty',
          description="CRAZY PARTY MODE",
          long_description="Kefka, Trooper, Banon, Leo, Ghost, Merchant, Esper Terra, "
                           "and Soldier are included in the pool of sprite randomization",
          category="sprite",
          inputtype="checkbox"),
-    Code(name='quikdraw',
+    Flag(name='quikdraw',
          description="QUIKDRAW MODE",
          long_description="All characters look like imperial soldiers, and none of them have Gau's Rage skill.",
          category="sprite",
          inputtype="checkbox"),
 
     # Aesthetic codes
-    Code(name='alasdraco',
+    Flag(name='alasdraco',
          description="JAM UP YOUR OPERA MODE",
          long_description="Randomizes various aesthetic elements of the Opera.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='bingoboingo',
+    Flag(name='bingoboingo',
          description="BINGO BONUS",
          long_description="Generates a Bingo table with various game elements to witness and check off. "
                           "The ROM does not interact with the bingo board.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='capslockoff',
+    Flag(name='capslockoff',
          description="Mixed Case Names Mode",
          long_description="Names use whatever capitalization is in the name lists instead of all caps.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='johnnydmad',
+    Flag(name='johnnydmad',
          description="MUSIC REPLACEMENT MODE",
          long_description="Randomizes music with regard to what would make sense in a given location.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='johnnyachaotic',
+    Flag(name='johnnyachaotic',
          description="MUSIC MANGLING MODE",
          long_description="Randomizes music with no regard to what would make sense in a given location.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='notawaiter',
+    Flag(name='notawaiter',
          description="CUTSCENE SKIPS",
          long_description="Up to Kefka at Narshe, the vast majority of mandatory cutscenes are completely removed. "
                           "Optional cutscenes are not removed.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='removeflashing',
+    Flag(name='removeflashing',
          description="NOT SO FLASHY MODE",
          long_description="Removes most white flashing effects from the game, such as Bum Rush.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='nicerpoison',
+    Flag(name='nicerpoison',
          description="LOW PIXELATION POISON MODE",
          long_description="Drastically reduces the pixelation effect of poison when in dungeons.",
          category="aesthetic",
          inputtype="checkbox"),
-    Code(name='remonsterate',
+    Flag(name='remonsterate',
          description="MONSTER SPRITE REPLACEMENT MODE",
          long_description="Replaces monster sprites with sprites from other games. "
                           "Requires sprites in the remonstrate\\sprites folder.",
@@ -568,100 +408,100 @@ NORMAL_CODES = [
          inputtype="checkbox"),
 
     # battle codes
-    Code(name='electricboogaloo',
+    Flag(name='electricboogaloo',
          description="WILD ITEM BREAK MODE",
          long_description="Increases the list of spells that items can break and proc for from just "
                           "magic and some summons to include almost any skill.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='collateraldamage',
+    Flag(name='collateraldamage',
          description="ITEM BREAK MODE",
          long_description="All pieces of equipment break for spells. Characters only have the Fight and "
                           "Item commands, and enemies will use items drastically more often than usual.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='masseffect',
+    Flag(name='masseffect',
          description="WILD EQUIPMENT EFFECT MODE",
          long_description="Increases the number of rogue effects on equipment by a large amount.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='randombosses',
+    Flag(name='randombosses',
          description="RANDOM BOSSES MODE",
          long_description="Causes boss skills to be randomized similarly to regular enemy skills. "
                           "Boss skills can change to similarly powerful skills.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='dancingmaduin',
+    Flag(name='dancingmaduin',
          description="RESTRICTED ESPERS MODE",
          long_description="Restricts Esper usage such that most Espers can only be equipped by one character. "
                           "Also usually changes what spell the Paladin Shld teaches.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='darkworld',
+    Flag(name='darkworld',
          description="SLASHER'S DELIGHT MODE",
          long_description="Drastically increases the difficulty of the seed, akin to a hard mode. "
-                          "Mostly meant to be used in conjunction with the madworld code.",
+                          "Mostly meant to be used in conjunction with the madworld flag.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='easymodo',
+    Flag(name='easymodo',
          description="EASY MODE",
          long_description="All enemies have 1 HP.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='madworld',
+    Flag(name='madworld',
          description="TIERS FOR FEARS MODE",
          long_description='Creates a "true tierless" seed, with enemies having a higher degree of '
                           'randomization and shops being very randomized as well.',
          category="battle",
          inputtype="checkbox"),
-    Code(name='playsitself',
+    Flag(name='playsitself',
          description="AUTOBATTLE MODE",
          long_description="All characters will act automatically, in a manner similar to "
                           "when Coliseum fights are fought.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='rushforpower',
+    Flag(name='rushforpower',
          description="OLD VARGAS FIGHT MODE",
          long_description="Reverts the Vargas fight to only require that Vargas take any "
                           "damage to begin his second phase.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='norng',
+    Flag(name='norng',
          description="NO RNG MODE",
          long_description="Almost all calls to the RNG are removed, and actions are much less random as a result.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='expboost',
+    Flag(name='expboost',
          description="MULTIPLIED EXP MODE",
          long_description="All battles will award multiplied exp.",
          category="battle",
          inputtype="float2"),
-    Code(name='gpboost',
+    Flag(name='gpboost',
          description="MULTIPLIED GP MODE",
          long_description="All battles will award multiplied gp.",
          category="battle",
          inputtype="float2"),
-    Code(name='mpboost',
+    Flag(name='mpboost',
          description="MULTIPLIED MP MODE",
          long_description="All battles will award multiplied magic points.",
          category="battle",
          inputtype="float2"),
-    Code(name='dancelessons',
+    Flag(name='dancelessons',
          description="NO DANCE FAILURES",
          long_description="Removes the 50% chance that dances will fail when used on a different terrain.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='nobreaks',
+    Flag(name='nobreaks',
          description="NO ITEM BREAKS MODE",
          long_description="Causes no items to break for spell effects.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='unbreakable',
+    Flag(name='unbreakable',
          description="UNBREAKABLE ITEMS MODE",
          long_description="Causes all items to be indestructible when broken for a spell.",
          category="battle",
          inputtype="checkbox"),
-    Code(name='swdtechspeed',
+    Flag(name='swdtechspeed',
          description="CHANGE SWDTECH SPEED MODE",
          long_description="Alters the speed at which the SwdTech bar moves.",
          category="battle",
@@ -669,135 +509,135 @@ NORMAL_CODES = [
          choices=("Fastest", "Faster", "Fast", "Vanilla", "Random"),
          default_value="Vanilla",
          default_index=3),
-    Code(name='cursepower',
+    Flag(name='cursepower',
          description="CHANGE CURSED SHIELD MODE",
          long_description="Set the number of battles required to uncurse a Cursed Shield. (Vanilla = 255, 0 = Random)",
          category="battle",
          inputtype="integer",
          default_value="255",
          maximum_value=255),
-    Code(name='lessfanatical',
+    Flag(name='lessfanatical',
          description="EASY FANATICS TOWER MODE",
          long_description="Disables forced magic command in Fanatic's Tower.",
          category="battle",
          inputtype="checkbox"),
 
     # field codes
-    Code(name='fightclub',
+    Flag(name='fightclub',
          description="MORE LIKE COLI-DON'T-SEE-'EM",
          long_description="Does not allow you to see the coliseum rewards before betting, "
                           "but you can often run from the coliseum battles to keep your item.",
          category="field",
          inputtype="checkbox"),
-    Code(name='bsiab',
+    Flag(name='bsiab',
          description="UNBALANCED MONSTER CHESTS MODE",
          long_description="Greatly increases the variance of monster-in-a-box encounters and removes "
                           "some sanity checks, allowing them to be much more difficult and volatile",
          category="field",
          inputtype="checkbox"),
-    Code(name='mimetime',
+    Flag(name='mimetime',
          description='ALTERNATE GOGO MODE',
          long_description="Gogo will be hidden somewhere in the World of Ruin disguised as another character. "
                           "Bring that character to him to recruit him.",
          category="field",
          inputtype="checkbox"),
-    Code(name='dearestmolulu',
+    Flag(name='dearestmolulu',
          description="ENCOUNTERLESS MODE",
          long_description="No random encounters occur. Items that alter encounter rates increase them. "
-                          "EXP code recommended",
+                          "EXP flag recommended",
          category="field",
          inputtype="checkbox"),
-    Code(name='randomboost',
+    Flag(name='randomboost',
          description="RANDOM BOOST MODE",
          long_description="Prompts for a multiplier, increasing the range of randomization. (0=uniform randomness)",
          category="field",
          inputtype="integer",
          default_value="0"),
-    Code(name='worringtriad',
+    Flag(name='worringtriad',
          description="START IN WOR",
          long_description="The player will start in the World of Ruin, with all of the World of Balance "
                           "treasure chests, along with a guaranteed set of items, and more Lores.",
          category="field",
          inputtype="checkbox"),
-    Code(name='questionablecontent',
+    Flag(name='questionablecontent',
          description="RIDDLER MODE",
          long_description="When items have significant differences from vanilla, a question mark "
                           "is appended to the item's name, including in shop menus.",
          category="field",
          inputtype="checkbox"),
-    Code(name='nomiabs',
+    Flag(name='nomiabs',
          description='NO MIAB MODE',
          long_description="Chests will never have monster encounters in them.",
          category="field",
          inputtype="checkbox"),
-    Code(name='cursedencounters',
+    Flag(name='cursedencounters',
          description="EXPANDED ENCOUNTERS MODE",
          long_description="Increases all zones to have 16 possible enemy encounters.",
          category="field",
          inputtype="checkbox"),
-    Code(name='morefanatical',
+    Flag(name='morefanatical',
          description='HORROR FANATICS TOWER',
          long_description="Fanatic's Tower is even more confusing than usual.",
          category="field",
          inputtype="checkbox"),
 
     # character codes
-    Code(name='replaceeverything',
+    Flag(name='replaceeverything',
          description="REPLACE ALL SKILLS MODE",
          long_description="All vanilla skills that can be replaced, are replaced.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='allcombos',
+    Flag(name='allcombos',
          description="ALL COMBOS MODE",
          long_description="All skills that get replaced with something are replaced with combo skills.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='nocombos',
+    Flag(name='nocombos',
          description="NO COMBOS MODE",
          long_description="There will be no combo(dual) skills.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='endless9',
+    Flag(name='endless9',
          description="ENDLESS NINE MODE",
          long_description="All R-[skills] are automatically changed to 9x[skills]. W-[skills] will become 8x[skills].",
          category="characters",
          inputtype="checkbox"),
-    Code(name='supernatural',
+    Flag(name='supernatural',
          description="SUPER NATURAL MAGIC MODE",
          long_description="Makes it so that any character with the Magic command will have natural magic.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='canttouchthis',
+    Flag(name='canttouchthis',
          description="INVINCIBILITY",
          long_description="All characters have 255 Defense and 255 Magic Defense, as well as 128 Evasion "
                           "and Magic Evasion.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='naturalstats',
+    Flag(name='naturalstats',
          description="NATURAL STATS MODE",
          long_description="No Espers will grant stat bonuses upon leveling up.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='metronome',
+    Flag(name='metronome',
          description="R-CHAOS MODE",
          long_description="All characters have Fight, R-Chaos, Magic, and Item as their skillset, "
                           "except for the Mime, who has Mimic instead of Fight, and the Berserker, "
                           "who only has R-Chaos.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='naturalmagic',
+    Flag(name='naturalmagic',
          description="NATURAL MAGIC MODE",
          long_description="No Espers or equipment will teach spells. The only way for characters to "
                           "learn spells is through leveling up, if they have their own innate magic list.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='suplexwrecks',
+    Flag(name='suplexwrecks',
          description="SUPLEX MODE",
          long_description="All characters use the Sabin sprite, have a name similar to Sabin, have the "
                           "Blitz and Suplex commands, and can hit every enemy with Suplex.",
          category="characters",
          inputtype="checkbox"),
-    Code(name='desperation',
+    Flag(name='desperation',
          description="DESPERATION MODE",
          long_description="Guarantees one character will have R-Limit, and greatly increases the chance "
                           "of having desperation attacks as commands.",
@@ -806,18 +646,18 @@ NORMAL_CODES = [
 
     # gamebreaking codes
 
-    Code(name='airship',
+    Flag(name='airship',
          description="AIRSHIP MODE",
          long_description="The player can access the airship after leaving Narshe, or from any chocobo stable. "
                           "Doing events out of order can cause softlocks.",
          category="gamebreaking",
          inputtype="checkbox"),
-    Code(name='sketch',
+    Flag(name='sketch',
          description="ENABLE SKETCH GLITCH",
          long_description="Enables sketch bug. Not recommended unless you know what you are doing.",
          category="gamebreaking",
          inputtype="checkbox"),
-    Code(name='equipanything',
+    Flag(name='equipanything',
          description="EQUIP ANYTHING MODE",
          long_description="Items that are not equippable normally can now be equipped as weapons or shields. "
                           "These often give strange defensive stats or weapon animations.",
@@ -825,20 +665,13 @@ NORMAL_CODES = [
          inputtype="checkbox"),
 
     # experimental codes
-
-    # Code(name='repairpalette',
-    # "PALETTE REPAIR",
-    # long_description="Used for testing changes to palette randomization. Not intended for actual play. "
-    #                  "Cannot proceed past Banon's scenario.",
-    # category="experimental",
-    # "checkbox"),
-    Code(name='strangejourney',
+    Flag(name='strangejourney',
          description="BIZARRE ADVENTURE",
          long_description="A prototype entrance randomizer, similar to the ancientcave mode. "
                           "Includes all maps and event tiles, and is usually extremely hard to beat by itself.",
          category="experimental",
          inputtype="checkbox"),
-    Code(name='thescenarionottaken',
+    Flag(name='thescenarionottaken',
          description='DIVERGENT PATHS MODE',
          long_description="Changes the way the 3 scenarios are split up, to resemble PowerPanda's "
                           "'Divergent Paths' mod.",
@@ -850,30 +683,29 @@ NORMAL_CODES = [
 ]
 
 # these are all sprite related codes
-MAKEOVER_MODIFIER_CODES = [
-    Code(name='novanilla',
+MAKEOVER_MODIFIER_FLAGS = [
+    Flag(name='novanilla',
          description="COMPLETE MAKEOVER MODE",
          long_description="Same as 'makeover' except sprites from the vanilla game are guaranteed "
                           "not to appear.",
          category="sprite",
          inputtype="checkbox"),
-    Code(name='frenchvanilla',
+    Flag(name='frenchvanilla',
          description="EQUAL RIGHTS MAKEOVER MODE",
          long_description="Same as 'makeover' except sprites from the vanilla game are selected "
                           "with equal weight to new sprites rather than some being guaranteed to appear.",
          category="sprite",
          inputtype="checkbox"),
-    Code(name='cloneparty',
+    Flag(name='cloneparty',
          description="CLONE COSPLAY MAKEOVER MODE",
          long_description="Same as 'makeover' except instead of avoiding choosing different "
                           "versions of the same character, it actively tries to do so.",
          category="sprite",
          inputtype="checkbox")
 ]
-RESTRICTED_VANILLA_SPRITE_CODES = []
+RESTRICTED_VANILLA_SPRITE_FLAGS = []
 
 # this is used for the makeover variation codes for sprites
-# makeover_groups = ["anime", "boys", "generic", "girls", "kids", "pets", "potato", "custom"]
 makeover_groups = None
 
 
@@ -895,15 +727,14 @@ def get_makeover_groups():
                     makeover_groups[group] = 1
 
         # this is used for the makeover variation codes for sprites
-        # makeover_groups = ["anime", "boys", "generic", "girls", "kids", "pets", "potato", "custom"]
         for mg in makeover_groups:
-            no = Code(name='no' + mg,
+            no = Flag(name='no' + mg,
                       description="NO {mg.upper()} ALLOWED MODE",
                       long_description="Do not select {mg} sprites.",
                       category="spriteCategories",
                       inputtype="checkbox")
-            MAKEOVER_MODIFIER_CODES.extend([
-                Code(name=mg,
+            MAKEOVER_MODIFIER_FLAGS.extend([
+                Flag(name=mg,
                      description="CUSTOM {mg.upper()} FREQUENCY MODE",
                      long_description="Adjust probability of selecting " + mg + " sprites.",
                      category="spriteCategories",
@@ -911,49 +742,49 @@ def get_makeover_groups():
                      choices=("Normal", "No", "Hate", "Like", "Only"),
                      default_value="Normal",
                      default_index=0)])
-            RESTRICTED_VANILLA_SPRITE_CODES.append(no)
+            RESTRICTED_VANILLA_SPRITE_FLAGS.append(no)
     except FileNotFoundError:
         pass
     return makeover_groups
 
 
 # TODO: do this a better way
-CAVE_CODES = [
-    Code(name='ancientcave',
+CAVE_FLAGS = [
+    Flag(name='ancientcave',
          description="ANCIENT CAVE MODE",
          long_description="",
          category="cave",
          inputtype="checkbox"),
-    Code(name='speedcave',
+    Flag(name='speedcave',
          description="SPEED CAVE MODE",
          long_description="",
          category="cave",
          inputtype="checkbox"),
-    Code(name='racecave',
+    Flag(name='racecave',
          description="RACE CAVE MODE",
          long_description="",
          category="cave",
          inputtype="checkbox"),
 ]
 
-SPECIAL_CODES = [
-    Code(name='christmas',
+SPECIAL_FLAGS = [
+    Flag(name='christmas',
          description='CHIRSTMAS MODE',
          long_description='',
          category='holiday',
          inputtype="checkbox"),
-    Code(name='halloween',
+    Flag(name='halloween',
          description="ALL HALLOWS' EVE MODE",
          long_description='',
          category='holiday',
          inputtype="checkbox")
 ]
 
-BETA_CODES = [
+BETA_FLAGS = [
 
 ]
 
-ALL_CODES = NORMAL_CODES + MAKEOVER_MODIFIER_CODES + CAVE_CODES + SPECIAL_CODES
+ALL_FLAGS = NORMAL_FLAGS + MAKEOVER_MODIFIER_FLAGS + CAVE_FLAGS + SPECIAL_FLAGS
 
 Options_ = Options(ALL_MODES[0])
 

--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -1,6 +1,7 @@
+import re
 from dataclasses import dataclass, field
 from typing import List, Set, Union
-from appearance import get_makeover_groups
+
 
 @dataclass(frozen=True)
 class Mode:
@@ -29,26 +30,79 @@ class Code:
     long_description: str
     category: str
     inputtype: str
-    choices: [str] = None
     key1: str = ''
     key2: str = ''
+    choices: [str] = field(default_factory=list)
+    default_index: int = 0
+    default_value: str = ""
+    minimum_value: int = 0
+    maximum_value: int = 255
 
-    def remove_from_string(self, s: str):
+    def remove_from_string(self, flag_string: str, mode: Mode):
         name = self.name
-        if name in s:
-            if name + ":" in s:
-                # A value was supplied, return the value
-                string_after_key = s[s.index(name + ":") + len(name + ":"):]
+        invert_simple_flags = flag_string.startswith("-")
+        if name in mode.prohibited_codes:
+            print("The code " + name + " has been deactivated. It is incompatible with " + mode.name + ".")
+            return False, False, re.sub(r'\b' + re.escape(name) + r'\b',
+                                        '',
+                                        flag_string,
+                                        re.IGNORECASE)
+        if name in flag_string:
+            # Search for a match starting with a word boundary, then the flag name, then :
+            if re.search(r'\b' + re.escape(name) + r":", flag_string):
+                # A value was supplied, get the value
+                string_after_key = flag_string[flag_string.index(name + ":") + len(name + ":"):]
                 try:
                     value = string_after_key[:string_after_key.index(" ")]
                 except ValueError:
                     # A space did not exist after the flag. Get the entire rest of the flag string.
                     value = string_after_key
-                return True, value, s.replace(name + ":" + value, '')
-            else:
-                # No value was supplied, return True
-                return True, True, s.replace(name, '')
-        return False, False, s
+
+                # After getting the value, if the code is in prohibited codes, we can just remove it
+                # There's no such thing as a flag with a supplied value, but we can check anyway.
+                if name in mode.prohibited_flags or name in mode.prohibited_codes:
+                    print("The code " + name + " has been deactivated. It is incompatible with " + mode.name + ".")
+                    return False, False, re.sub(r'\b' + re.escape(name) + r':' + re.escape(value) + r'\b',
+                                                '',
+                                                flag_string,
+                                                re.IGNORECASE)
+                else:
+                    return True, value, re.sub(r'\b' + re.escape(name) + r':' + re.escape(value) + r'\b',
+                                               '',
+                                               flag_string,
+                                               re.IGNORECASE)
+
+            # Search for a match starting with a word boundary, then the flag name, then another word boundary
+            elif re.search(r'\b' + re.escape(name) + r"\b", flag_string):
+                # Check if the name is in prohibited flags or prohibited codes
+                if name in mode.prohibited_flags or name in mode.prohibited_codes:
+                    print("The flag " + name + " has been deactivated. It is incompatible with " + mode.name + ".")
+                    return False, False, re.sub(r'\b' + re.escape(name) + r'\b',
+                                                '',
+                                                flag_string,
+                                                re.IGNORECASE)
+                elif len(name) == 1 and invert_simple_flags:
+                    return False, False, re.sub(r'\b' + re.escape(name) + r'\b',
+                                                '',
+                                                flag_string,
+                                                re.IGNORECASE)
+                else:
+                    # No value was supplied, return True
+                    return True, True, re.sub(r'\b' + re.escape(name) + r'\b',
+                                              '',
+                                              flag_string,
+                                              re.IGNORECASE)
+        else:
+            # The code was not found in the flag string.
+            # Check if the code is a flag (len = 1) and invert the return value if a dash begins the flag string
+            if len(name) == 1 and invert_simple_flags and not \
+                    (name in mode.prohibited_flags or name in mode.prohibited_codes):
+                return True, True, re.sub(r'\b' + re.escape(name) + r'\b',
+                                          '',
+                                          flag_string,
+                                          re.IGNORECASE)
+        flag_string = str.strip(flag_string)
+        return False, False, flag_string
 
 
 @dataclass
@@ -83,7 +137,7 @@ class Options:
     def is_code_active(self, code_name: str):
         if code_name in self.active_codes.keys():
             return True
-        #for code in self.active_codes:
+        # for code in self.active_codes:
         #    if code.name == code_name:
         #        return True
         return False
@@ -92,7 +146,7 @@ class Options:
         for code in code_names:
             if code in self.active_codes.keys():
                 return True
-        #for code in self.active_codes:
+        # for code in self.active_codes:
         #    if code.name in code_names:
         #        return True
         return False
@@ -103,11 +157,12 @@ class Options:
         except KeyError:
             return None
 
-    def is_flag_active(self, flag_name: str):
-        for flag in self.active_flags:
-            if flag.name == flag_name:
-                return True
-        return False
+    # Commented out because it was unused
+    # def is_flag_active(self, flag_name: str):
+    #     for flag in self.active_flags:
+    #         if flag.name == flag_name:
+    #             return True
+    #     return False
 
     def activate_code(self, code_name: str, code_value=None):
         for code in ALL_CODES:
@@ -119,25 +174,24 @@ class Options:
                     self.activate_code("frenchvanilla")
                 return
 
-    def activate_flag(self, flag: Flag):
-        self.active_flags.add(flag)
-        setattr(self, flag.attr, True)
+    # Commented out because it was unused
+    # def activate_flag(self, flag: Flag):
+    #     self.active_flags.add(flag)
+    #     setattr(self, flag.description, True)
 
     def activate_from_string(self, flag_string):
         for code in self.mode.forced_codes:
             self.activate_code(code)
 
         s = ""
-        flags, codes = read_Options_from_string(flag_string, self.mode)
+        #flags, codes = read_Options_from_string(flag_string, self.mode)
+        codes = read_Options_from_string(flag_string, self.mode)
         for code, value in codes.items():
             if code == 'sketch' and ('sketch' in codes.keys() and 'remonsterate' in codes.keys()):
                 s += f"SECRET CODE: 'sketch' is not compatible with remonsterate code.\n"
                 continue
-            if code in self.mode.prohibited_codes:
-                s += f"SECRET CODE: '{code}' is not compatible with {self.mode.name} mode.\n"
-                continue
             for code_object in NORMAL_CODES + MAKEOVER_MODIFIER_CODES:
-                if code_object.name == code:
+                if code_object.name == code and len(code_object.name) > 1:
                     if code_object.category == "spriteCategories":
                         s += f"SECRET CODE: {str(value).upper()} {str(code).upper()} MODE ACTIVATED\n"
                     else:
@@ -147,39 +201,42 @@ class Options:
         if self.is_code_active('strangejourney'):
             self.activate_code('notawaiter')
 
-        flags -= self.mode.prohibited_flags
-        if not flags:
-            flags = {f for f in ALL_FLAGS if f not in self.mode.prohibited_flags}
-
-        for flag in flags:
-            self.activate_flag(flag)
+        # flags -= self.mode.prohibited_flags
+        # if not flags:
+        #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f not in self.mode.prohibited_flags}
+        #
+        # for flag in flags:
+        #     self.activate_flag(flag)
 
         return s
 
 
 def read_Options_from_string(flag_string: str, mode: Union[Mode, str]):
-    flags = set()
+    # flags = set()
     codes = {}
 
     if isinstance(mode, str):
         mode = [m for m in ALL_MODES if m.name == mode][0]
 
     for code in NORMAL_CODES + MAKEOVER_MODIFIER_CODES:
-        found, value, flag_string = code.remove_from_string(flag_string)
+        if len(flag_string) == 0:
+            break
+        found, value, flag_string = code.remove_from_string(flag_string, mode)
         if found:
             codes[code.name] = value
+    # if '-' in flag_string:
+    #     print("NOTE: Using all flags EXCEPT the specified flags.")
+    #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f.name not in flag_string}
+    # else:
+    #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f.name in flag_string}
+    #
+    # flags -= mode.prohibited_flags
+    # if not flags:
+    #     flags = {f for f in NORMAL_CODES if f.category == "flags" and f not in mode.prohibited_flags}
 
-    if '-' in flag_string:
-        print("NOTE: Using all flags EXCEPT the specified flags.")
-        flags = {f for f in ALL_FLAGS if f.name not in flag_string}
-    else:
-        flags = {f for f in ALL_FLAGS if f.name in flag_string}
+    # return flags, codes
+    return codes
 
-    flags -= mode.prohibited_flags
-    if not flags:
-        flags = {f for f in ALL_FLAGS if f not in mode.prohibited_flags}
-
-    return flags, codes
 
 ANCIENT_CAVE_PROHIBITED_CODES = [
     "airship",
@@ -217,9 +274,11 @@ ALL_MODES = [
          prohibited_codes=ANCIENT_CAVE_PROHIBITED_CODES,
          prohibited_flags=ANCIENT_CAVE_PROHIBITED_FLAGS),
     Mode(name="katn",
-         description="Play the normal story up to Kefka at Narshe. Intended for racing.", # Static number of encounters on Lete River, No charm drops, Start with random Espers, Curated enemy specials, Banned Baba Breath & Seize
+         description="Play the normal story up to Kefka at Narshe. Intended for racing.",
          prohibited_codes=["airship", "alasdraco", "worringtriad", "mimetime"],
          prohibited_flags={"d", "k", "r"}),
+    # Static number of encounters on Lete River, No charm drops, Start with random Espers,
+    # Curated enemy specials, Banned Baba Breath & Seize
     Mode(name="dragonhunt",
          description="Kill all 8 dragons in the World of Ruin. Intended for racing.",
          forced_codes=["worringtriad"],
@@ -227,112 +286,575 @@ ALL_MODES = [
          prohibited_flags={"j"}),
 ]
 
-ALL_FLAGS = [
-    Flag('b', 'fix_exploits', 'Make the game more balanced by removing known exploits.', "checkbox"),
-    Flag('c', 'random_palettes_and_names', 'Randomize palettes and names of various things.', "checkbox"),
-    Flag('d', 'random_final_dungeon', 'Randomize final dungeon.', "checkbox"),
-    Flag('e', 'random_espers', 'Randomize esper spells and levelup bonuses.', "checkbox"),
-    Flag('f', 'random_formations', 'Randomize enemy formations.', "checkbox"),
-    Flag('g', 'random_dances', 'Randomize dances.', "checkbox"),
-    Flag('h', 'random_final_party', 'Your party in the Final Kefka fight will be random.', "checkbox"),
-    Flag('i', 'random_items', 'Randomize the stats of equippable items.', "checkbox"),
-    Flag('j', 'randomize_forest', 'Randomize the phantom forest.', "checkbox"),
-    Flag('k', 'random_clock', 'Randomize the clock in Zozo.', "checkbox"),
-    Flag('l', 'random_blitz', 'Randomize blitz inputs.', "checkbox"),
-    Flag('m', 'random_enemy_stats', 'Randomize enemy stats.', "checkbox"),
-    Flag('n', 'random_window', 'Randomize window background colors.', "checkbox"),
-    Flag('o', 'shuffle_commands', "Shuffle characters' in-battle commands.", "checkbox"),
-    Flag('p', 'random_animation_palettes', 'Randomize the palettes of spells and weapon animations.', "checkbox"),
-    Flag('q', 'random_character_stats', 'Randomize what equipment each character can wear and character stats.', "checkbox"),
-    Flag('r', 'shuffle_wor', 'Randomize character locations in the world of ruin.', "checkbox"),
-    Flag('s', 'swap_sprites', 'Swap character graphics around.', "checkbox"),
-    Flag('t', 'random_treasure', 'Randomize treasure, including chests, colosseum, shops, and enemy drops.', "checkbox"),
-    Flag('u', 'random_zerker', 'Umaro risk. (Random character will be berserk)', "checkbox"),
-    Flag('w', 'replace_commands', 'Generate new commands for characters, replacing old commands.', "checkbox"),
-    Flag('y', 'randomize_magicite', 'Shuffle magicite locations.', "checkbox"),
-    Flag('z', 'sprint', 'Always have "Sprint Shoes" effect.', "checkbox"),
-]
-
+# ALL_FLAGS = [
+#     Flag(name='b',
+#          description='fix_exploits',
+#          long_description='Make the game more balanced by removing known exploits.',
+#          inputtype="checkbox"),
+#     Flag(name='c',
+#          description='random_palettes_and_names',
+#          long_description='Randomize palettes and names of various things.',
+#          inputtype="checkbox"),
+#     Flag(name='d',
+#          description='random_final_dungeon',
+#          long_description='Randomize final dungeon.',
+#          inputtype="checkbox"),
+#     Flag(name='e',
+#          description='random_espers',
+#          long_description='Randomize esper spells and levelup bonuses.',
+#          inputtype="checkbox"),
+#     Flag(name='f',
+#          description='random_formations',
+#          long_description='Randomize enemy formations.',
+#          inputtype="checkbox"),
+#     Flag(name='g',
+#          description='random_dances',
+#          long_description='Randomize dances.',
+#          inputtype="checkbox"),
+#     Flag(name='h',
+#          description='random_final_party',
+#          long_description='Your party in the Final Kefka fight will be random.',
+#          inputtype="checkbox"),
+#     Flag(name='i',
+#          description='random_items',
+#          long_description='Randomize the stats of equippable items.',
+#          inputtype="checkbox"),
+#     Flag(name='j',
+#          description='randomize_forest',
+#          long_description='Randomize the phantom forest.',
+#          inputtype="checkbox"),
+#     Flag(name='k',
+#          description='random_clock',
+#          long_description='Randomize the clock in Zozo.',
+#          inputtype="checkbox"),
+#     Flag(name='l',
+#          description='random_blitz',
+#          long_description='Randomize blitz inputs.',
+#          inputtype="checkbox"),
+#     Flag(name='m',
+#          description='random_enemy_stats',
+#          long_description='Randomize enemy stats.',
+#          inputtype="checkbox"),
+#     Flag(name='n',
+#          description='random_window',
+#          long_description='Randomize window background colors.',
+#          inputtype="checkbox"),
+#     Flag(name='o',
+#          description='shuffle_commands',
+#          long_description="Shuffle characters' in-battle commands.",
+#          inputtype="checkbox"),
+#     Flag(name='p',
+#          description='random_animation_palettes',
+#          long_description='Randomize the palettes of spells and weapon animations.',
+#          inputtype="checkbox"),
+#     Flag(name='q',
+#          description='random_character_stats',
+#          long_description='Randomize what equipment each character can wear and character stats.',
+#          inputtype="checkbox"),
+#     Flag(name='r',
+#          description='shuffle_wor',
+#          long_description='Randomize character locations in the world of ruin.',
+#          inputtype="checkbox"),
+#     Flag(name='s',
+#          description='swap_sprites',
+#          long_description='Swap character graphics around.',
+#          inputtype="checkbox"),
+#     Flag(name='t',
+#          description='random_treasure',
+#          long_description='Randomize treasure including chests, colosseum, shops, and enemy drops.',
+#          inputtype="checkbox"),
+#     Flag(name='u',
+#          description='random_zerker',
+#          long_description='Umaro risk. (Random character will be berserk)',
+#          inputtype="checkbox"),
+#     Flag(name='w',
+#          description='replace_commands',
+#          long_description='Generate new commands for characters,replacing old commands.',
+#          inputtype="checkbox"),
+#     Flag(name='y',
+#          description='randomize_magicite',
+#          long_description='Shuffle magicite locations.',
+#          inputtype="checkbox"),
+#     Flag(name='z',
+#          description='sprint',
+#          long_description='Always have "Sprint Shoes" effect.',
+#          inputtype="checkbox"),
+# ]
 
 NORMAL_CODES = [
+    # Flags
+    Code(name='b',
+         description='fix_exploits',
+         long_description='Make the game more balanced by removing known exploits.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='c',
+         description='random_palettes_and_names',
+         long_description='Randomize palettes and names of various things.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='d',
+         description='random_final_dungeon',
+         long_description='Randomize final dungeon.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='e',
+         description='random_espers',
+         long_description='Randomize esper spells and levelup bonuses.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='f',
+         description='random_formations',
+         long_description='Randomize enemy formations.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='g',
+         description='random_dances',
+         long_description='Randomize dances.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='h',
+         description='random_final_party',
+         long_description='Your party in the Final Kefka fight will be random.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='i',
+         description='random_items',
+         long_description='Randomize the stats of equippable items.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='j',
+         description='randomize_forest',
+         long_description='Randomize the phantom forest.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='k',
+         description='random_clock',
+         long_description='Randomize the clock in Zozo.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='l',
+         description='random_blitz',
+         long_description='Randomize blitz inputs.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='m',
+         description='random_enemy_stats',
+         long_description='Randomize enemy stats.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='n',
+         description='random_window',
+         long_description='Randomize window background colors.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='o',
+         description='shuffle_commands',
+         long_description="Shuffle characters' in-battle commands.",
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='p',
+         description='random_animation_palettes',
+         long_description='Randomize the palettes of spells and weapon animations.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='q',
+         description='random_character_stats',
+         long_description='Randomize what equipment each character can wear and character stats.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='r',
+         description='shuffle_wor',
+         long_description='Randomize character locations in the world of ruin.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='s',
+         description='swap_sprites',
+         long_description='Swap character graphics around.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='t',
+         description='random_treasure',
+         long_description='Randomize treasure including chests, colosseum, shops, and enemy drops.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='u',
+         description='random_zerker',
+         long_description='Umaro risk. (Random character will be berserk)',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='w',
+         description='replace_commands',
+         long_description='Generate new commands for characters,replacing old commands.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='y',
+         description='randomize_magicite',
+         long_description='Shuffle magicite locations.',
+         category="flags",
+         inputtype="checkbox"),
+    Code(name='z',
+         description='sprint',
+         long_description='Always have "Sprint Shoes" effect.',
+         category="flags",
+         inputtype="checkbox"),
+
     # Sprite codes
-    Code('bravenudeworld', "TINA PARTY MODE", "All characters use the Esper Terra sprite.", "sprite", "checkbox"),
-    Code('makeover', "SPRITE REPLACEMENT MODE", "Some sprites are replaced with new ones (like Cecil or Zero Suit Samus).", "sprite", "checkbox"),
-    Code('kupokupo', "MOOGLE MODE", "All party members are moogles except Mog. With partyparty, all characters are moogles, except Mog, Esper Terra, and Imps.", "sprite", "checkbox"),
-    Code('partyparty', "CRAZY PARTY MODE", "Kefka, Trooper, Banon, Leo, Ghost, Merchant, Esper Terra, and Soldier are included in the pool of sprite randomization", "sprite", "checkbox"),
-    Code('quikdraw', "QUIKDRAW MODE", "All characters look like imperial soldiers, and none of them have Gau's Rage skill.", "sprite", "checkbox"),
+    Code(name='bravenudeworld',
+         description="TINA PARTY MODE",
+         long_description="All characters use the Esper Terra sprite.",
+         category="sprite",
+         inputtype="checkbox"),
+    Code(name='makeover',
+         description="SPRITE REPLACEMENT MODE",
+         long_description="Some sprites are replaced with new ones (like Cecil or Zero Suit Samus).",
+         category="sprite",
+         inputtype="checkbox"),
+    Code(name='kupokupo',
+         description="MOOGLE MODE",
+         long_description="All party members are moogles except Mog. With partyparty, "
+                          "all characters are moogles, except Mog, Esper Terra, and Imps.",
+         category="sprite",
+         inputtype="checkbox"),
+    Code(name='partyparty',
+         description="CRAZY PARTY MODE",
+         long_description="Kefka, Trooper, Banon, Leo, Ghost, Merchant, Esper Terra, "
+                          "and Soldier are included in the pool of sprite randomization",
+         category="sprite",
+         inputtype="checkbox"),
+    Code(name='quikdraw',
+         description="QUIKDRAW MODE",
+         long_description="All characters look like imperial soldiers, and none of them have Gau's Rage skill.",
+         category="sprite",
+         inputtype="checkbox"),
 
     # Aesthetic codes
-    Code('alasdraco', "JAM UP YOUR OPERA MODE", "Randomizes various aesthetic elements of the Opera.", "aesthetic", "checkbox"),
-    Code('bingoboingo', "BINGO BONUS", "Generates a Bingo table with various game elements to witness and check off. The ROM does not interact with the bingo board.", "aesthetic", "checkbox"),
-    Code('capslockoff', "Mixed Case Names Mode", "Names use whatever capitalization is in the name lists instead of all caps.", "aesthetic", "checkbox"),
-    Code('johnnydmad', "MUSIC REPLACEMENT MODE", "Randomizes music with regard to what would make sense in a given location.", "aesthetic", "checkbox"),
-    Code('johnnyachaotic', "MUSIC MANGLING MODE", "Randomizes music with no regard to what would make sense in a given location.", "aesthetic", "checkbox"),
-    Code('notawaiter', "CUTSCENE SKIPS", "Up to Kefka at Narshe, the vast majority of mandatory cutscenes are completely removed. Optional cutscenes are not removed.", "aesthetic", "checkbox"),
-    Code('removeflashing', "NOT SO FLASHY MODE", "Removes most white flashing effects from the game, such as Bum Rush.", "aesthetic", "checkbox"),
-    Code('nicerpoison', "LOW PIXELATION POISON MODE", "Drastically reduces the pixelation effect of poison when in dungeons.", "aesthetic", "checkbox"),
-    Code('remonsterate', "MONSTER SPRITE REPLACEMENT MODE", "Replaces monster sprites with sprites from other games. Requires sprites in the remonstrate\\sprites folder.", "aesthetic", "checkbox"),
+    Code(name='alasdraco',
+         description="JAM UP YOUR OPERA MODE",
+         long_description="Randomizes various aesthetic elements of the Opera.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='bingoboingo',
+         description="BINGO BONUS",
+         long_description="Generates a Bingo table with various game elements to witness and check off. "
+                          "The ROM does not interact with the bingo board.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='capslockoff',
+         description="Mixed Case Names Mode",
+         long_description="Names use whatever capitalization is in the name lists instead of all caps.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='johnnydmad',
+         description="MUSIC REPLACEMENT MODE",
+         long_description="Randomizes music with regard to what would make sense in a given location.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='johnnyachaotic',
+         description="MUSIC MANGLING MODE",
+         long_description="Randomizes music with no regard to what would make sense in a given location.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='notawaiter',
+         description="CUTSCENE SKIPS",
+         long_description="Up to Kefka at Narshe, the vast majority of mandatory cutscenes are completely removed. "
+                          "Optional cutscenes are not removed.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='removeflashing',
+         description="NOT SO FLASHY MODE",
+         long_description="Removes most white flashing effects from the game, such as Bum Rush.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='nicerpoison',
+         description="LOW PIXELATION POISON MODE",
+         long_description="Drastically reduces the pixelation effect of poison when in dungeons.",
+         category="aesthetic",
+         inputtype="checkbox"),
+    Code(name='remonsterate',
+         description="MONSTER SPRITE REPLACEMENT MODE",
+         long_description="Replaces monster sprites with sprites from other games. "
+                          "Requires sprites in the remonstrate\\sprites folder.",
+         category="aesthetic",
+         inputtype="checkbox"),
 
     # battle codes
-    Code('electricboogaloo', "WILD ITEM BREAK MODE", "Increases the list of spells that items can break and proc for from just magic and some summons to include almost any skill.", "battle", "checkbox"),
-    Code('collateraldamage', "ITEM BREAK MODE", "All pieces of equipment break for spells. Characters only have the Fight and Item commands, and enemies will use items drastically more often than usual.", "battle", "checkbox"),
-    Code('masseffect', "WILD EQUIPMENT EFFECT MODE", "Increases the number of rogue effects on equipment by a large amount.", "battle", "checkbox"),
-    Code('randombosses', "RANDOM BOSSES MODE", "Causes boss skills to be randomized similarly to regular enemy skills. Boss skills can change to similarly powerful skills.", "battle", "checkbox"),
-    Code('dancingmaduin', "RESTRICTED ESPERS MODE", "Restricts Esper usage such that most Espers can only be equipped by one character. Also usually changes what spell the Paladin Shld teaches.", "battle", "checkbox"),
-    Code('darkworld', "SLASHER'S DELIGHT MODE", "Drastically increases the difficulty of the seed, akin to a hard mode. Mostly meant to be used in conjunction with the madworld code.", "battle", "checkbox"),
-    Code('easymodo', "EASY MODE", "All enemies have 1 HP.", "battle", "checkbox"),
-    Code('madworld', "TIERS FOR FEARS MODE", 'Creates a "true tierless" seed, with enemies having a higher degree of randomization and shops being very randomized as well.', "battle", "checkbox"),
-    Code('playsitself', "AUTOBATTLE MODE", "All characters will act automatically, in a manner similar to when Coliseum fights are fought.", "battle", "checkbox"),
-    Code('rushforpower', "OLD VARGAS FIGHT MODE", "Reverts the Vargas fight to only require that Vargas take any damage to begin his second phase.", "battle", "checkbox"),
-    Code('norng', "NO RNG MODE", "Almost all calls to the RNG are removed, and actions are much less random as a result.", "battle", "checkbox"),
-    Code('expboost', "MULTIPLIED EXP MODE", "All battles will award multiplied exp.", "battle", "numberbox"),
-    Code('gpboost', "MULTIPLIED GP MODE", "All battles will award multiplied gp.", "battle", "numberbox"),
-    Code('mpboost', "MULTIPLIED MP MODE", "All battles will award multiplied magic points.", "battle", "numberbox"),
-    Code('dancelessons', "NO DANCE FAILURES", "Removes the 50% chance that dances will fail when used on a different terrain.", "battle", "checkbox"),
-    Code('nobreaks', "NO ITEM BREAKS MODE", "Causes no items to break for spell effects.", "battle", "checkbox"),
-    Code('unbreakable', "UNBREAKABLE ITEMS MODE", "Causes all items to be indestructible when broken for a spell.", "battle", "checkbox"),
-    Code('swdtechspeed', "CHANGE SWDTECH SPEED MODE", "Alters the speed at which the SwdTech bar moves.", "battle", "combobox", ("Fastest", "Faster", "Fast", "Vanilla", "Random")),
-    Code('cursepower', "CHANGE CURSED SHIELD MODE", "Set the number of battles required to uncurse a Cursed Shield. (Vanilla = 256, 0 = Random)", "battle", "numberbox"),
-    Code('lessfanatical', "EASY FANATICS TOWER MODE", "Disables forced magic command in Fanatic's Tower.", "battle", "checkbox"),
+    Code(name='electricboogaloo',
+         description="WILD ITEM BREAK MODE",
+         long_description="Increases the list of spells that items can break and proc for from just "
+                          "magic and some summons to include almost any skill.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='collateraldamage',
+         description="ITEM BREAK MODE",
+         long_description="All pieces of equipment break for spells. Characters only have the Fight and "
+                          "Item commands, and enemies will use items drastically more often than usual.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='masseffect',
+         description="WILD EQUIPMENT EFFECT MODE",
+         long_description="Increases the number of rogue effects on equipment by a large amount.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='randombosses',
+         description="RANDOM BOSSES MODE",
+         long_description="Causes boss skills to be randomized similarly to regular enemy skills. "
+                          "Boss skills can change to similarly powerful skills.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='dancingmaduin',
+         description="RESTRICTED ESPERS MODE",
+         long_description="Restricts Esper usage such that most Espers can only be equipped by one character. "
+                          "Also usually changes what spell the Paladin Shld teaches.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='darkworld',
+         description="SLASHER'S DELIGHT MODE",
+         long_description="Drastically increases the difficulty of the seed, akin to a hard mode. "
+                          "Mostly meant to be used in conjunction with the madworld code.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='easymodo',
+         description="EASY MODE",
+         long_description="All enemies have 1 HP.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='madworld',
+         description="TIERS FOR FEARS MODE",
+         long_description='Creates a "true tierless" seed, with enemies having a higher degree of '
+                          'randomization and shops being very randomized as well.',
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='playsitself',
+         description="AUTOBATTLE MODE",
+         long_description="All characters will act automatically, in a manner similar to "
+                          "when Coliseum fights are fought.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='rushforpower',
+         description="OLD VARGAS FIGHT MODE",
+         long_description="Reverts the Vargas fight to only require that Vargas take any "
+                          "damage to begin his second phase.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='norng',
+         description="NO RNG MODE",
+         long_description="Almost all calls to the RNG are removed, and actions are much less random as a result.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='expboost',
+         description="MULTIPLIED EXP MODE",
+         long_description="All battles will award multiplied exp.",
+         category="battle",
+         inputtype="float2"),
+    Code(name='gpboost',
+         description="MULTIPLIED GP MODE",
+         long_description="All battles will award multiplied gp.",
+         category="battle",
+         inputtype="float2"),
+    Code(name='mpboost',
+         description="MULTIPLIED MP MODE",
+         long_description="All battles will award multiplied magic points.",
+         category="battle",
+         inputtype="float2"),
+    Code(name='dancelessons',
+         description="NO DANCE FAILURES",
+         long_description="Removes the 50% chance that dances will fail when used on a different terrain.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='nobreaks',
+         description="NO ITEM BREAKS MODE",
+         long_description="Causes no items to break for spell effects.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='unbreakable',
+         description="UNBREAKABLE ITEMS MODE",
+         long_description="Causes all items to be indestructible when broken for a spell.",
+         category="battle",
+         inputtype="checkbox"),
+    Code(name='swdtechspeed',
+         description="CHANGE SWDTECH SPEED MODE",
+         long_description="Alters the speed at which the SwdTech bar moves.",
+         category="battle",
+         inputtype="combobox",
+         choices=("Fastest", "Faster", "Fast", "Vanilla", "Random"),
+         default_value="Vanilla",
+         default_index=3),
+    Code(name='cursepower',
+         description="CHANGE CURSED SHIELD MODE",
+         long_description="Set the number of battles required to uncurse a Cursed Shield. (Vanilla = 255, 0 = Random)",
+         category="battle",
+         inputtype="integer",
+         default_value="255",
+         maximum_value=255),
+    Code(name='lessfanatical',
+         description="EASY FANATICS TOWER MODE",
+         long_description="Disables forced magic command in Fanatic's Tower.",
+         category="battle",
+         inputtype="checkbox"),
 
     # field codes
-    Code('fightclub', "MORE LIKE COLI-DON'T-SEE-'EM",  "Does not allow you to see the coliseum rewards before betting, but you can often run from the coliseum battles to keep your item.",  "field", "checkbox"),
-    Code('bsiab', "UNBALANCED MONSTER CHESTS MODE", "Greatly increases the variance of monster-in-a-box encounters and removes some sanity checks, allowing them to be much more difficult and volatile", "field", "checkbox"),
-    Code('mimetime', 'ALTERNATE GOGO MODE', "Gogo will be hidden somewhere in the World of Ruin disguised as another character. Bring that character to him to recruit him.", "field", "checkbox"),
-    Code('dearestmolulu', "ENCOUNTERLESS MODE", "No random encounters occur. Items that alter encounter rates increase them. EXP code recommended", "field", "checkbox"),
-    Code('randomboost', "RANDOM BOOST MODE",  "Prompts for a multiplier, increasing the range of randomization. (0=uniform randomness)", "field", "numberbox"),
-    Code('worringtriad', "START IN WOR", "The player will start in the World of Ruin, with all of the World of Balance treasure chests, along with a guaranteed set of items, and more Lores.", "field", "checkbox"),
-    Code('questionablecontent', "RIDDLER MODE", "When items have significant differences from vanilla, a question mark is appended to the item's name, including in shop menus.", "field", "checkbox"),
-    Code('nomiabs', 'NO MIAB MODE', "Chests will never have monster encounters in them.", "field", "checkbox"),
-    Code('cursedencounters', "EXPANDED ENCOUNTERS MODE", "Increases all zones to have 16 possible enemy encounters.", "field", "checkbox"),
-    Code('morefanatical', 'HORROR FANATICS TOWER', "Fanatic's Tower is even more confusing than usual.", "field", "checkbox"),
-
+    Code(name='fightclub',
+         description="MORE LIKE COLI-DON'T-SEE-'EM",
+         long_description="Does not allow you to see the coliseum rewards before betting, "
+                          "but you can often run from the coliseum battles to keep your item.",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='bsiab',
+         description="UNBALANCED MONSTER CHESTS MODE",
+         long_description="Greatly increases the variance of monster-in-a-box encounters and removes "
+                          "some sanity checks, allowing them to be much more difficult and volatile",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='mimetime',
+         description='ALTERNATE GOGO MODE',
+         long_description="Gogo will be hidden somewhere in the World of Ruin disguised as another character. "
+                          "Bring that character to him to recruit him.",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='dearestmolulu',
+         description="ENCOUNTERLESS MODE",
+         long_description="No random encounters occur. Items that alter encounter rates increase them. "
+                          "EXP code recommended",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='randomboost',
+         description="RANDOM BOOST MODE",
+         long_description="Prompts for a multiplier, increasing the range of randomization. (0=uniform randomness)",
+         category="field",
+         inputtype="integer",
+         default_value="0"),
+    Code(name='worringtriad',
+         description="START IN WOR",
+         long_description="The player will start in the World of Ruin, with all of the World of Balance "
+                          "treasure chests, along with a guaranteed set of items, and more Lores.",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='questionablecontent',
+         description="RIDDLER MODE",
+         long_description="When items have significant differences from vanilla, a question mark "
+                          "is appended to the item's name, including in shop menus.",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='nomiabs',
+         description='NO MIAB MODE',
+         long_description="Chests will never have monster encounters in them.",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='cursedencounters',
+         description="EXPANDED ENCOUNTERS MODE",
+         long_description="Increases all zones to have 16 possible enemy encounters.",
+         category="field",
+         inputtype="checkbox"),
+    Code(name='morefanatical',
+         description='HORROR FANATICS TOWER',
+         long_description="Fanatic's Tower is even more confusing than usual.",
+         category="field",
+         inputtype="checkbox"),
 
     # character codes
-    Code('replaceeverything', "REPLACE ALL SKILLS MODE", "All vanilla skills that can be replaced, are replaced.", "characters", "checkbox"),
-    Code('allcombos', "ALL COMBOS MODE", "All skills that get replaced with something are replaced with combo skills.", "characters", "checkbox"),
-    Code('nocombos', "NO COMBOS MODE", "There will be no combo(dual) skills.", "characters", "checkbox"),
-    Code('endless9', "ENDLESS NINE MODE", "All R-[skills] are automatically changed to 9x[skills]. W-[skills] will become 8x[skills].", "characters", "checkbox"),
-    Code('supernatural', "SUPER NATURAL MAGIC MODE", "Makes it so that any character with the Magic command will have natural magic.", "characters", "checkbox"),
-    Code('canttouchthis', "INVINCIBILITY", "All characters have 255 Defense and 255 Magic Defense, as well as 128 Evasion and Magic Evasion.", "characters", "checkbox"),
-    Code('naturalstats', "NATURAL STATS MODE", "No Espers will grant stat bonuses upon leveling up.", "characters", "checkbox"),
-    Code('metronome', "R-CHAOS MODE", "All characters have Fight, R-Chaos, Magic, and Item as their skillset, except for the Mime, who has Mimic instead of Fight, and the Berserker, who only has R-Chaos.", "characters", "checkbox"),
-    Code('naturalmagic', "NATURAL MAGIC MODE", "No Espers or equipment will teach spells. The only way for characters to learn spells is through leveling up, if they have their own innate magic list.", "characters", "checkbox"),
-    Code('suplexwrecks', "SUPLEX MODE", "All characters use the Sabin sprite, have a name similar to Sabin, have the Blitz and Suplex commands, and can hit every enemy with Suplex.", "characters", "checkbox"),
-    Code('desperation', "DESPERATION MODE", "Guarantees one character will have R-Limit, and greatly increases the chance of having desperation attacks as commands.", "characters", "checkbox"),
+    Code(name='replaceeverything',
+         description="REPLACE ALL SKILLS MODE",
+         long_description="All vanilla skills that can be replaced, are replaced.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='allcombos',
+         description="ALL COMBOS MODE",
+         long_description="All skills that get replaced with something are replaced with combo skills.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='nocombos',
+         description="NO COMBOS MODE",
+         long_description="There will be no combo(dual) skills.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='endless9',
+         description="ENDLESS NINE MODE",
+         long_description="All R-[skills] are automatically changed to 9x[skills]. W-[skills] will become 8x[skills].",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='supernatural',
+         description="SUPER NATURAL MAGIC MODE",
+         long_description="Makes it so that any character with the Magic command will have natural magic.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='canttouchthis',
+         description="INVINCIBILITY",
+         long_description="All characters have 255 Defense and 255 Magic Defense, as well as 128 Evasion "
+                          "and Magic Evasion.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='naturalstats',
+         description="NATURAL STATS MODE",
+         long_description="No Espers will grant stat bonuses upon leveling up.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='metronome',
+         description="R-CHAOS MODE",
+         long_description="All characters have Fight, R-Chaos, Magic, and Item as their skillset, "
+                          "except for the Mime, who has Mimic instead of Fight, and the Berserker, "
+                          "who only has R-Chaos.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='naturalmagic',
+         description="NATURAL MAGIC MODE",
+         long_description="No Espers or equipment will teach spells. The only way for characters to "
+                          "learn spells is through leveling up, if they have their own innate magic list.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='suplexwrecks',
+         description="SUPLEX MODE",
+         long_description="All characters use the Sabin sprite, have a name similar to Sabin, have the "
+                          "Blitz and Suplex commands, and can hit every enemy with Suplex.",
+         category="characters",
+         inputtype="checkbox"),
+    Code(name='desperation',
+         description="DESPERATION MODE",
+         long_description="Guarantees one character will have R-Limit, and greatly increases the chance "
+                          "of having desperation attacks as commands.",
+         category="characters",
+         inputtype="checkbox"),
 
     # gamebreaking codes
 
-    Code('airship', "AIRSHIP MODE", "The player can access the airship after leaving Narshe, or from any chocobo stable. Doing events out of order can cause softlocks.", "gamebreaking", "checkbox"),
-    Code('sketch', "ENABLE SKETCH GLITCH", "Enables sketch bug. Not recommended unless you know what you are doing.", "gamebreaking", "checkbox"),
-    Code('equipanything', "EQUIP ANYTHING MODE", "Items that are not equippable normally can now be equipped as weapons or shields. These often give strange defensive stats or weapon animations.", "gamebreaking", "checkbox"),
+    Code(name='airship',
+         description="AIRSHIP MODE",
+         long_description="The player can access the airship after leaving Narshe, or from any chocobo stable. "
+                          "Doing events out of order can cause softlocks.",
+         category="gamebreaking",
+         inputtype="checkbox"),
+    Code(name='sketch',
+         description="ENABLE SKETCH GLITCH",
+         long_description="Enables sketch bug. Not recommended unless you know what you are doing.",
+         category="gamebreaking",
+         inputtype="checkbox"),
+    Code(name='equipanything',
+         description="EQUIP ANYTHING MODE",
+         long_description="Items that are not equippable normally can now be equipped as weapons or shields. "
+                          "These often give strange defensive stats or weapon animations.",
+         category="gamebreaking",
+         inputtype="checkbox"),
 
     # experimental codes
 
-    #Code('repairpalette', "PALETTE REPAIR", "Used for testing changes to palette randomization. Not intended for actual play. Cannot proceed past Banon's scenario.", "experimental", "checkbox"),
-    Code('strangejourney', "BIZARRE ADVENTURE", "A prototype entrance randomizer, similar to the ancientcave mode. Includes all maps and event tiles, and is usually extremely hard to beat by itself.", "experimental", "checkbox"),
-    Code('thescenarionottaken', 'DIVERGENT PATHS MODE', "Changes the way the 3 scenarios are split up, to resemble PowerPanda's 'Divergent Paths' mod.", "experimental", "checkbox"),
-
+    # Code(name='repairpalette',
+    # "PALETTE REPAIR",
+    # long_description="Used for testing changes to palette randomization. Not intended for actual play. "
+    #                  "Cannot proceed past Banon's scenario.",
+    # category="experimental",
+    # "checkbox"),
+    Code(name='strangejourney',
+         description="BIZARRE ADVENTURE",
+         long_description="A prototype entrance randomizer, similar to the ancientcave mode. "
+                          "Includes all maps and event tiles, and is usually extremely hard to beat by itself.",
+         category="experimental",
+         inputtype="checkbox"),
+    Code(name='thescenarionottaken',
+         description='DIVERGENT PATHS MODE',
+         long_description="Changes the way the 3 scenarios are split up, to resemble PowerPanda's "
+                          "'Divergent Paths' mod.",
+         category="experimental",
+         inputtype="checkbox"),
 
     # beta codes
 
@@ -340,42 +862,106 @@ NORMAL_CODES = [
 
 # these are all sprite related codes
 MAKEOVER_MODIFIER_CODES = [
-    Code('novanilla', "COMPLETE MAKEOVER MODE", "Same as 'makeover' except sprites from the vanilla game are guaranteed not to appear.", "sprite", "checkbox"),
-    Code('frenchvanilla', "EQUAL RIGHTS MAKEOVER MODE", "Same as 'makeover' except sprites from the vanilla game are selected with equal weight to new sprites rather than some being guaranteed to appear.", "sprite", "checkbox"),
-    Code('cloneparty', "CLONE COSPLAY MAKEOVER MODE", "Same as 'makeover' except instead of avoiding choosing different versions of the same character, it actively tries to do so.", "sprite", "checkbox")
+    Code(name='novanilla',
+         description="COMPLETE MAKEOVER MODE",
+         long_description="Same as 'makeover' except sprites from the vanilla game are guaranteed "
+                          "not to appear.",
+         category="sprite",
+         inputtype="checkbox"),
+    Code(name='frenchvanilla',
+         description="EQUAL RIGHTS MAKEOVER MODE",
+         long_description="Same as 'makeover' except sprites from the vanilla game are selected "
+                          "with equal weight to new sprites rather than some being guaranteed to appear.",
+         category="sprite",
+         inputtype="checkbox"),
+    Code(name='cloneparty',
+         description="CLONE COSPLAY MAKEOVER MODE",
+         long_description="Same as 'makeover' except instead of avoiding choosing different "
+                          "versions of the same character, it actively tries to do so.",
+         category="sprite",
+         inputtype="checkbox")
 ]
 RESTRICTED_VANILLA_SPRITE_CODES = []
 
 # this is used for the makeover variation codes for sprites
 # makeover_groups = ["anime", "boys", "generic", "girls", "kids", "pets", "potato", "custom"]
 makeover_groups = None
-try:
-    makeover_groups = get_makeover_groups()
-    for mg in makeover_groups:
-        no = Code('no'+mg, f"NO {mg.upper()} ALLOWED MODE", f"Do not select {mg} sprites.", "spriteCategories", "checkbox")
-        MAKEOVER_MODIFIER_CODES.extend([
-            Code(mg, f"CUSTOM {mg.upper()} FREQUENCY MODE", f"Adjust probability of selecting {mg} sprites.",
-                 "spriteCategories", "combobox", ("Normal", "No", "Hate", "Like", "Only"))])
-        RESTRICTED_VANILLA_SPRITE_CODES.append(no)
-except FileNotFoundError:
-    pass
+
+
+def get_makeover_groups():
+    try:
+        global makeover_groups
+        if makeover_groups:
+            return makeover_groups
+
+        from appearance import get_sprite_replacements
+        sprite_replacements = get_sprite_replacements()
+        makeover_groups = {}
+
+        for sr in sprite_replacements:
+            for group in sr.groups:
+                if group in makeover_groups:
+                    makeover_groups[group] = makeover_groups[group] + 1
+                else:
+                    makeover_groups[group] = 1
+
+        # this is used for the makeover variation codes for sprites
+        # makeover_groups = ["anime", "boys", "generic", "girls", "kids", "pets", "potato", "custom"]
+        for mg in makeover_groups:
+            no = Code(name='no' + mg,
+                      description="NO {mg.upper()} ALLOWED MODE",
+                      long_description="Do not select {mg} sprites.",
+                      category="spriteCategories",
+                      inputtype="checkbox")
+            MAKEOVER_MODIFIER_CODES.extend([
+                Code(name=mg,
+                     description="CUSTOM {mg.upper()} FREQUENCY MODE",
+                     long_description="Adjust probability of selecting " + mg + " sprites.",
+                     category="spriteCategories",
+                     inputtype="combobox",
+                     choices=("Normal", "No", "Hate", "Like", "Only"),
+                     default_value="Normal",
+                     default_index=0)])
+            RESTRICTED_VANILLA_SPRITE_CODES.append(no)
+    except FileNotFoundError:
+        pass
+    return makeover_groups
 
 
 # TODO: do this a better way
 CAVE_CODES = [
-    Code('ancientcave', "ANCIENT CAVE MODE", "", "cave", "checkbox"),
-    Code('speedcave', "SPEED CAVE MODE", "", "cave", "checkbox"),
-    Code('racecave', "RACE CAVE MODE", "", "cave", "checkbox"),
+    Code(name='ancientcave',
+         description="ANCIENT CAVE MODE",
+         long_description="",
+         category="cave",
+         inputtype="checkbox"),
+    Code(name='speedcave',
+         description="SPEED CAVE MODE",
+         long_description="",
+         category="cave",
+         inputtype="checkbox"),
+    Code(name='racecave',
+         description="RACE CAVE MODE",
+         long_description="",
+         category="cave",
+         inputtype="checkbox"),
 ]
 
-
 SPECIAL_CODES = [
-    Code('christmas', 'CHIRSTMAS MODE', '', 'holiday', "checkbox"),
-    Code('halloween', "ALL HALLOWS' EVE MODE", '', 'holiday', "checkbox")
+    Code(name='christmas',
+         description='CHIRSTMAS MODE',
+         long_description='',
+         category='holiday',
+         inputtype="checkbox"),
+    Code(name='halloween',
+         description="ALL HALLOWS' EVE MODE",
+         long_description='',
+         category='holiday',
+         inputtype="checkbox")
 ]
 
 BETA_CODES = [
-    
+
 ]
 
 ALL_CODES = NORMAL_CODES + MAKEOVER_MODIFIER_CODES + CAVE_CODES + SPECIAL_CODES

--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -127,7 +127,7 @@ class Options:
         s = ""
         flags = read_Options_from_string(flag_string, self.mode)
 
-        for flag in flags:
+        for flag in flags.values():
             # Detect incompatible and prohibited flags
             if flag.name in self.mode.prohibited_flags:
                 # The flag is prohibited. Notify the user and do not activate it.
@@ -154,7 +154,7 @@ class Options:
 
 
 def read_Options_from_string(flag_string: str, mode: Union[Mode, str]):
-    flags = set()
+    flags = {}
 
     if isinstance(mode, str):
         mode = [m for m in ALL_MODES if m.name == mode][0]
@@ -165,7 +165,7 @@ def read_Options_from_string(flag_string: str, mode: Union[Mode, str]):
         found, value, flag_string = flag.remove_from_string(flag_string, mode)
         if found:
             flag.value = value
-            flags.add(flag)
+            flags[flag.name] = flag
 
     return flags
 

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -44,7 +44,7 @@ from monsterrandomizer import (REPLACE_ENEMIES, MonsterGraphicBlock, get_monster
                                change_enemy_name, randomize_enemy_name,
                                get_collapsing_house_help_skill)
 from musicinterface import randomize_music, manage_opera, get_music_spoiler, music_init, get_opera_log
-from options import ALL_MODES, NORMAL_CODES, Options_
+from options import ALL_MODES, NORMAL_FLAGS, Options_
 from patches import (allergic_dog, banon_life3, vanish_doom, evade_mblock,
                      death_abuse, no_kutan_skip, show_coliseum_rewards,
                      cycle_statuses, no_dance_stumbles, fewer_flashes,
@@ -540,10 +540,10 @@ class WindowBlock():
         f = open(filename, 'r+b')
         f.seek(self.pointer)
         self.palette = []
-        if Options_.is_code_active('christmas'):
+        if Options_.is_flag_active('christmas'):
             self.palette = [(0x1c, 0x02, 0x04)] * 2 + [(0x19, 0x00, 0x06)] * 2 + [(0x03, 0x0d, 0x07)] * 2 + [
                 (0x18, 0x18, 0x18)] + [(0x04, 0x13, 0x0a)]
-        elif Options_.is_code_active('halloween'):
+        elif Options_.is_flag_active('halloween'):
             self.palette = [(0x04, 0x0d, 0x15)] * 2 + [(0x00, 0x00, 0x00)] + [(0x0b, 0x1d, 0x15)] + [
                 (0x00, 0x11, 0x00)] + [(0x1e, 0x00, 0x00)] + [(0x1d, 0x1c, 0x00)] + [(0x1c, 0x1f, 0x1b)]
         else:
@@ -563,7 +563,7 @@ class WindowBlock():
             write_multi(fout, color, length=2)
 
     def mutate(self):
-        if Options_.is_code_active('halloween'):
+        if Options_.is_flag_active('halloween'):
             return
 
         def cluster_colors(colors: List) -> List:
@@ -598,7 +598,7 @@ class WindowBlock():
             degree = random.randint(-75, 75)
             darken = random.uniform(prevdarken, min(prevdarken * 1.1, 1.0))
             darkener = lambda c: int(round(c * darken))
-            if Options_.is_code_active('christmas'):
+            if Options_.is_flag_active('christmas'):
                 hueswap = lambda w: w
             else:
                 hueswap = generate_swapfunc()
@@ -670,7 +670,7 @@ def randomize_colosseum(filename: str, fout: BinaryIO, pointer: int) -> List:
 
     results = sorted(results, key=lambda a_b_c_d: a_b_c_d[0].name)
 
-    if Options_.is_code_active('fightclub'):
+    if Options_.is_flag_active('fightclub'):
         coliseum_run_sub = Substitution()
         coliseum_run_sub.bytestring = [0xEA] * 2
         coliseum_run_sub.set_location(0x25BEF)
@@ -866,14 +866,14 @@ def manage_commands(commands: Dict[str, CommandBlock]):
     ungray_statscreen_sub.write(fout)
 
     fanatics_fix_sub = Substitution()
-    if Options_.is_code_active('metronome'):
+    if Options_.is_flag_active('metronome'):
         fanatics_fix_sub.bytestring = bytes([0xA9, 0x1D])
     else:
         fanatics_fix_sub.bytestring = bytes([0xA9, 0x15])
     fanatics_fix_sub.set_location(0x2537E)
     fanatics_fix_sub.write(fout)
 
-    if Options_.is_code_active('lessfanatical'): #remove the magic only tile when entering fanatic's tower
+    if Options_.is_flag_active('lessfanatical'): #remove the magic only tile when entering fanatic's tower
         fanatics_fix_sub.bytestring = bytes([0x80])
         fanatics_fix_sub.set_location(0x025352)
         fanatics_fix_sub.write(fout)
@@ -902,7 +902,7 @@ def manage_commands(commands: Dict[str, CommandBlock]):
                 # Fixing Gau
               c.set_battle_command(0, commands["fight"])
 
-        if Options_.is_code_active('metronome'):
+        if Options_.is_flag_active('metronome'):
             c.set_battle_command(0, command_id=0)
             c.set_battle_command(1, command_id=0x1D)
             c.set_battle_command(2, command_id=2)
@@ -910,7 +910,7 @@ def manage_commands(commands: Dict[str, CommandBlock]):
             c.write_battle_commands(fout)
             continue
 
-        if Options_.is_code_active('collateraldamage'):
+        if Options_.is_flag_active('collateraldamage'):
             c.set_battle_command(1, command_id=0xFF)
             c.set_battle_command(2, command_id=0xFF)
             c.set_battle_command(3, command_id=1)
@@ -956,7 +956,7 @@ def manage_commands(commands: Dict[str, CommandBlock]):
 
 
 def manage_tempchar_commands():
-    if Options_.is_code_active('metronome'):
+    if Options_.is_flag_active('metronome'):
         return
     characters = get_characters()
     chardict = {c.id: c for c in characters}
@@ -1042,7 +1042,7 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
         if c.name in NEVER_REPLACE:
             continue
 
-        if not Options_.is_code_active("replaceeverything"):
+        if not Options_.is_flag_active("replaceeverything"):
             if c.name in RESTRICTED_REPLACE and random.choice([True, False]):
                 continue
 
@@ -1053,7 +1053,7 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
         changed_commands.add(c.id)
         x = random.randint(1, 3)
 
-        if Options_.is_code_active('nocombos'):
+        if Options_.is_flag_active('nocombos'):
             x = random.randint(1, 2)
 
         if x <= 1:
@@ -1066,13 +1066,13 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
             random_skill = False
             combo_skill = True
 
-        if Options_.is_code_active('allcombos'):
+        if Options_.is_flag_active('allcombos'):
             random_skill = False
             combo_skill = True
 
         # force first skill to limit break
-        if limitCounter != 1 and Options_.is_code_active('desperation'):
-            if Options_.is_code_active('allcombos'):
+        if limitCounter != 1 and Options_.is_flag_active('desperation'):
+            if Options_.is_flag_active('allcombos'):
                 random_skill = False
                 combo_skill = True
             else:
@@ -1084,7 +1084,7 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
         while random.randint(1, 5) == 5:
             scount += 1
         scount = min(scount, 9)
-        if Options_.is_code_active("endless9"):
+        if Options_.is_flag_active("endless9"):
             scount = 9
 
         def get_random_power() -> int:
@@ -1110,7 +1110,7 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
 
                 valid_spells = list(filter(spell_is_valid, all_spells))
 
-                if Options_.is_code_active('desperation'):
+                if Options_.is_flag_active('desperation'):
                     desperations = {
                         "Sabre Soul", "Star Prism", "Mirager", "TigerBreak",
                         "Back Blade", "Riot Blade", "RoyalShock", "Spin Edge",
@@ -1170,7 +1170,7 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
                 c.set_retarget(fout)
                 valid_spells = [v for v in all_spells if
                                 v.spellid <= 0xED and v.valid]
-                if Options_.is_code_active('desperation'):
+                if Options_.is_flag_active('desperation'):
                     for spell in all_spells:
                         if spell.name == "Sabre Soul":
                             if spell not in valid_spells: valid_spells.append(spell)
@@ -1207,14 +1207,14 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
                         s = ChainSpellSub()
 
                 try:
-                    if limitCounter != 1 and Options_.is_code_active('desperation'):
+                    if limitCounter != 1 and Options_.is_flag_active('desperation'):
                         s.set_spells(valid_spells, "Limit", None)
                         limitCounter = limitCounter + 1
                     else:
                         limitbad = True
                         s.set_spells(valid_spells)
                         while limitbad:
-                            if s.name == "Limit" and not Options_.is_code_active('desperation'):
+                            if s.name == "Limit" and not Options_.is_flag_active('desperation'):
                                 s.set_spells(valid_spells)
                             else:
                                 limitbad = False
@@ -1265,7 +1265,7 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
                     valid_spells = [s for s in all_spells
                                     if spell_is_valid(s, power) and s not in myspells]
 
-                    if Options_.is_code_active('desperation'):
+                    if Options_.is_flag_active('desperation'):
                         for spell in all_spells:
                             if spell.name == "Sabre Soul":
                                 if spell not in valid_spells: valid_spells.append(spell)
@@ -1441,7 +1441,7 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
         c.newname(newname, fout)
         c.unsetmenu(fout)
         c.allow_while_confused(fout)
-        if Options_.is_code_active('playsitself'):
+        if Options_.is_flag_active('playsitself'):
             c.allow_while_berserk(fout)
         else:
             c.disallow_while_berserk(fout)
@@ -1449,12 +1449,12 @@ def manage_commands_new(commands: Dict[str, CommandBlock]):
         command_descr = "{0}\n-------\n{1}".format(c.name, str(s))
         log(command_descr, 'commands')
 
-    if Options_.is_code_active('metronome'):
+    if Options_.is_flag_active('metronome'):
         magitek = [c for c in commands.values() if c.name == "magitek"][0]
         magitek.read_properties(sourcefile)
         magitek.targeting = 0x04
         magitek.set_retarget(fout)
-        if Options_.is_code_active("endless9"):
+        if Options_.is_flag_active("endless9"):
             s = MultipleSpellSub()
             s.set_count(9)
             magitek.newname("9xChaos", fout)
@@ -1543,7 +1543,7 @@ def manage_natural_magic():
     candidates = [c for c in characters if c.id < 12 and (0x02 in c.battle_commands or 0x17 in c.battle_commands)]
 
     num_natural_mages = 1
-    if Options_.is_code_active('supernatural'):
+    if Options_.is_flag_active('supernatural'):
         num_natural_mages = len(candidates)
     else:
         if random.randint(0, 9) != 9:
@@ -1727,7 +1727,7 @@ def manage_umaro(commands: Dict[str, CommandBlock]):
     if 0xFF in umaro_risk.battle_commands:
         battle_commands = []
         battle_commands.append(0)
-        if not Options_.is_code_active("collateraldamage"):
+        if not Options_.is_flag_active("collateraldamage"):
             battle_commands.extend(random.sample([3, 5, 6, 7, 8, 9, 0xA, 0xB,
                                                   0xC, 0xD, 0xE, 0xF, 0x10,
                                                   0x12, 0x13, 0x16, 0x18, 0x1A,
@@ -1752,7 +1752,7 @@ def manage_umaro(commands: Dict[str, CommandBlock]):
     umaro.beserk = False
     umaro_risk.beserk = True
 
-    if Options_.is_code_active('metronome'):
+    if Options_.is_flag_active('metronome'):
         umaro_risk.battle_commands = [0x1D, 0xFF, 0xFF, 0xFF]
 
     umaro_risk.write_battle_commands(fout)
@@ -1835,7 +1835,7 @@ def manage_skips():
 
     def handleGau(split_line: List[str]):  # Replace events that should be replaced if we are auto-recruiting Gau
         # at least for now, divergent paths doesn't skip the cutscene with Gau
-        if Options_.is_code_active("thescenarionottaken"):
+        if Options_.is_flag_active("thescenarionottaken"):
             return
         if Options_.shuffle_commands or Options_.replace_commands or Options_.random_treasure:
             writeToAddress(split_line[0], split_line[1:])
@@ -1849,17 +1849,17 @@ def manage_skips():
                 palette_correct_sub.write(fout)
 
     def handleConvergentPalette(split_line: List[str]):
-        if Options_.is_code_active('thescenarionottaken'):
+        if Options_.is_flag_active('thescenarionottaken'):
             return
         handlePalette(split_line)
 
     def handleDivergentPalette(split_line: List[str]):
-        if not Options_.is_code_active('thescenarionottaken'):
+        if not Options_.is_flag_active('thescenarionottaken'):
             return
         handlePalette(split_line)
 
     def handleAirship(split_line: List[str]):  # Replace events that should be modified if we start with the airship
-        if not Options_.is_code_active('airship'):
+        if not Options_.is_flag_active('airship'):
             writeToAddress(split_line[0], split_line[1:])
         else:
             writeToAddress(split_line[0],
@@ -1874,17 +1874,17 @@ def manage_skips():
                            )
 
     def handleConvergent(split_line: List[str]):  # Replace events that should be modified if the scenarios are changed
-        if Options_.is_code_active('thescenarionottaken'):
+        if Options_.is_flag_active('thescenarionottaken'):
             return
         handleNormal(split_line)
 
     def handleDivergent(split_line: List[str]):  # Replace events that should be modified if the scenarios are changed
-        if not Options_.is_code_active('thescenarionottaken'):
+        if not Options_.is_flag_active('thescenarionottaken'):
             return
         handleNormal(split_line)
 
     def handleStrange(split_line: List[str]):  # Replace extra events that must be trimmed from Strange Journey
-        if not Options_.is_code_active('strangejourney'):
+        if not Options_.is_flag_active('strangejourney'):
             return
         handleNormal(split_line)
 
@@ -2118,7 +2118,7 @@ def set_lete_river_encounters():
     manage_lete_river_sub.set_location(0xB048F)
     manage_lete_river_sub.write(fout)
     # call subroutine CB0498 (4 bytes)
-    if Options_.is_code_active('thescenarionottaken'):
+    if Options_.is_flag_active('thescenarionottaken'):
         battle_calls = [0xB066B,
                         0xB0690,
                         0xB06A4,
@@ -2172,7 +2172,7 @@ def set_lete_river_encounters():
             manage_lete_river_sub.set_location(addr)
             manage_lete_river_sub.write(fout)
 
-    if not Options_.is_code_active("thescenarionottaken"):
+    if not Options_.is_flag_active("thescenarionottaken"):
         if random.randint(0, 1) == 0:
             manage_lete_river_sub.bytestring = bytes([0xFD] * 8)
             manage_lete_river_sub.set_location(0xB09C8)
@@ -2182,7 +2182,7 @@ def set_lete_river_encounters():
 
 def manage_rng():
     fout.seek(0xFD00)
-    if Options_.is_code_active('norng'):
+    if Options_.is_flag_active('norng'):
         numbers = [0 for _ in range(0x100)]
     else:
         numbers = list(range(0x100))
@@ -2319,14 +2319,14 @@ def manage_final_boss(freespaces: list):
 
 def manage_monsters() -> List[MonsterBlock]:
     monsters = get_monsters(sourcefile)
-    safe_solo_terra = not Options_.is_code_active("ancientcave")
-    darkworld = Options_.is_code_active("darkworld")
+    safe_solo_terra = not Options_.is_flag_active("ancientcave")
+    darkworld = Options_.is_flag_active("darkworld")
     change_skillset = None
     katn = Options_.mode.name == 'katn'
     final_bosses = (list(range(0x157, 0x160)) + list(range(0x127, 0x12b)) + [0x112, 0x11a, 0x17d])
     for m in monsters:
         if "zone eater" in m.name.lower():
-            if Options_.is_code_active("norng"):
+            if Options_.is_flag_active("norng"):
                 m.aiscript = [b.replace(b"\x10", b"\xD5") for b in m.aiscript]
             continue
         if not m.name.strip('_') and not m.display_name.strip('_'):
@@ -2359,7 +2359,7 @@ def manage_monsters() -> List[MonsterBlock]:
 
     shuffle_monsters(monsters, safe_solo_terra=safe_solo_terra)
     for m in monsters:
-        m.randomize_special_effect(fout, halloween=Options_.is_code_active('halloween'))
+        m.randomize_special_effect(fout, halloween=Options_.is_flag_active('halloween'))
         m.write_stats(fout)
 
     return monsters
@@ -2453,12 +2453,12 @@ def manage_colorize_animations():
 
 def manage_items(items: List[ItemBlock], changed_commands: Set[int] = None) -> List[ItemBlock]:
     from itemrandomizer import (set_item_changed_commands, extend_item_breaks)
-    always_break = Options_.is_code_active('collateraldamage')
-    crazy_prices = Options_.is_code_active('madworld')
-    extra_effects = Options_.is_code_active('masseffect')
-    wild_breaks = Options_.is_code_active('electricboogaloo')
-    no_breaks = Options_.is_code_active('nobreaks')
-    unbreakable = Options_.is_code_active('unbreakable')
+    always_break = Options_.is_flag_active('collateraldamage')
+    crazy_prices = Options_.is_flag_active('madworld')
+    extra_effects = Options_.is_flag_active('masseffect')
+    wild_breaks = Options_.is_flag_active('electricboogaloo')
+    no_breaks = Options_.is_flag_active('nobreaks')
+    unbreakable = Options_.is_flag_active('unbreakable')
 
     set_item_changed_commands(changed_commands)
     unhardcode_tintinabar(fout)
@@ -2535,7 +2535,7 @@ def manage_equipment(items: List[ItemBlock]) -> List[ItemBlock]:
                        "relic": lambda i: i.is_relic}
 
     tempchars = [14, 15, 16, 17, 32, 33] + list(range(18, 28))
-    if Options_.is_code_active('ancientcave'):
+    if Options_.is_flag_active('ancientcave'):
         tempchars += [41, 42, 43]
     for c in characters:
         if c.id >= 14 and c.id not in tempchars:
@@ -2798,7 +2798,7 @@ def manage_espers(freespaces: List[FreeBlock], replacements: dict = None) -> Lis
     espers = get_espers(sourcefile)
     random.shuffle(espers)
     for e in espers:
-        e.generate_spells(tierless=Options_.is_code_active('madworld'))
+        e.generate_spells(tierless=Options_.is_flag_active('madworld'))
         e.generate_bonus()
 
     if replacements:
@@ -2864,7 +2864,7 @@ def manage_treasure(monsters: List[MonsterBlock], shops=True, no_charm_drops=Fal
     if shops:
         buyables = manage_shops()
 
-    if Options_.is_code_active("ancientcave") or Options_.mode.name == 'katn':
+    if Options_.is_flag_active("ancientcave") or Options_.mode.name == 'katn':
         return
 
     pointer = 0x1fb600
@@ -2960,9 +2960,9 @@ def manage_doom_gaze(fout):
     set_dialogue(0x60, "<choice> (Lift-off)<line><choice> (Find Doom Gaze)<line><choice> (Not just yet)")
 
 def manage_chests():
-    crazy_prices = Options_.is_code_active('madworld')
-    no_monsters = Options_.is_code_active('nomiabs')
-    uncapped_monsters = Options_.is_code_active('bsiab')
+    crazy_prices = Options_.is_flag_active('madworld')
+    no_monsters = Options_.is_flag_active('nomiabs')
+    uncapped_monsters = Options_.is_flag_active('bsiab')
     locations = get_locations(sourcefile)
     locations = sorted(locations, key=lambda l: l.rank())
     for l in locations:
@@ -3200,7 +3200,7 @@ def manage_formations(formations: List[Formation], fsets: List[FormationSet], mp
                                                                    0x1E0, 0x1E6]}
 
     for formation in formations:
-        formation.mutate(mp=False, mp_boost_value=Options_.get_code_value('mpboost'))
+        formation.mutate(mp=False, mp_boost_value=Options_.get_flag_value('mpboost'))
         if formation.formid == 0x1e2:
             formation.set_music(2)  # change music for Atma fight
         if formation.formid == 0x162:
@@ -3219,7 +3219,7 @@ def manage_formations_hidden(formations: List[Formation],
     if not form_music_overrides:
         form_music_overrides = {}
     for f in formations:
-        f.mutate(mp=True, mp_boost_value=Options_.get_code_value('mpboost'))
+        f.mutate(mp=True, mp_boost_value=Options_.get_flag_value('mpboost'))
 
     unused_enemies = [u for u in get_monsters() if u.id in REPLACE_ENEMIES]
 
@@ -3465,7 +3465,7 @@ def assign_unused_enemy_formations():
 def manage_shops() -> Set[int]:
     buyables = set([])
     descriptions = []
-    crazy_shops = Options_.is_code_active("madworld")
+    crazy_shops = Options_.is_flag_active("madworld")
 
     for s in get_shops(sourcefile):
         s.mutate_items(fout, crazy_shops)
@@ -3474,7 +3474,7 @@ def manage_shops() -> Set[int]:
         buyables |= set(s.items)
         descriptions.append(str(s))
 
-    if not Options_.is_code_active("ancientcave"): #only logs vanilla shops anyways
+    if not Options_.is_flag_active("ancientcave"): #only logs vanilla shops anyways
         for d in sorted(descriptions):
             log(d, section="shops")
 
@@ -3591,7 +3591,7 @@ def manage_colorize_dungeons(locations=None, freespaces=None):
                 write_multi(fout, c, length=2)
             done.append(p)
 
-    if Options_.random_animation_palettes or Options_.swap_sprites or Options_.is_code_active('partyparty'):
+    if Options_.random_animation_palettes or Options_.swap_sprites or Options_.is_flag_active('partyparty'):
         manage_colorize_wor()
         manage_colorize_esper_world()
 
@@ -3648,7 +3648,7 @@ def manage_colorize_esper_world():
 
 
 def manage_encounter_rate() -> None:
-    if Options_.is_code_active('dearestmolulu'):
+    if Options_.is_flag_active('dearestmolulu'):
         overworld_rates = bytes([1, 0, 1, 0, 1, 0, 0, 0,
                                  0xC0, 0, 0x60, 0, 0x80, 1, 0, 0,
                                  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -3760,7 +3760,7 @@ def manage_encounter_rate() -> None:
 
 def manage_tower():
     locations = get_locations()
-    randomize_tower(filename=sourcefile, morefanatical=Options_.is_code_active("morefanatical"))
+    randomize_tower(filename=sourcefile, morefanatical=Options_.is_flag_active("morefanatical"))
     for l in locations:
         if l.locid in [0x154, 0x155] + list(range(104, 108)):
             # leo's thamasa, etc
@@ -4108,10 +4108,10 @@ def manage_opening():
 
     from string import ascii_letters as alpha
     consonants = "".join([c for c in alpha if c not in "aeiouy"])
-    flag_names = [f for f in Options_.active_codes.keys() if len(f) == 1]
+    flag_names = [f for f in Options_.active_flags.keys() if len(f) == 1]
     display_flags = sorted([a for a in alpha if a in flag_names])
     text = "".join([consonants[int(i)] for i in str(seed)])
-    codestatus = "CODES ON" if Options_.active_codes else "CODES OFF"
+    flagstatus = "FLAGS ON" if Options_.active_flags else "FLAGS OFF"
     display_flags = "".join(display_flags).upper()
     replace_credits_text(0x659C, "ffvi")
     replace_credits_text(0x65A9, "BEYOND CHAOS CE")
@@ -4130,7 +4130,7 @@ def manage_opening():
     replace_credits_text(0x66D8, display_flags, split=True)
     replace_credits_text(0x66FB, "")
     replace_credits_text(0x670D, "")
-    replace_credits_text(0x6732, codestatus)
+    replace_credits_text(0x6732, flagstatus)
     replace_credits_text(0x6758, "seed")
     replace_credits_text(0x676A, text.upper())
     replace_credits_text(0x6791, "ver.")
@@ -4420,7 +4420,7 @@ def namingway():
 
     set_dialogue(0x4E, "Rename lead character?<line><choice> (Yes)<line><choice> (No)")
 
-    if not Options_.is_code_active('ancientcave'):
+    if not Options_.is_flag_active('ancientcave'):
 
         wor_airship = get_location(0xC)
         wor_namer = NPCBlock(pointer=None, locid=wor_airship.locid)
@@ -4609,7 +4609,7 @@ def manage_spookiness():
     n_o_e_s_c_a_p_e_sub = Substitution()
     n_o_e_s_c_a_p_e_sub.bytestring = bytes([0x4B, 0xAE, 0x42])
     locations = [0xCA1C8, 0xCA296, 0xB198B]
-    if not Options_.is_code_active('notawaiter'):
+    if not Options_.is_flag_active('notawaiter'):
         locations.extend([0xA89BF, 0xB1963])
     for location in locations:
         n_o_e_s_c_a_p_e_sub.set_location(location)
@@ -4624,7 +4624,7 @@ def manage_spookiness():
     nowhere_to_run_sub = Substitution()
     nowhere_to_run_sub.bytestring = bytes([0x4B, 0xB3, 0x42])
     locations = [0xCA215, 0xCA270, 0xC8293]
-    if not Options_.is_code_active('notawaiter'):
+    if not Options_.is_flag_active('notawaiter'):
         locations.extend([0xB19B5, 0xB19F0])
     for location in locations:
         nowhere_to_run_sub.set_location(location)
@@ -4633,7 +4633,7 @@ def manage_spookiness():
     nowhere_to_run_bottom_sub = Substitution()
     nowhere_to_run_bottom_sub.bytestring = bytes([0x4B, 0xB3, 0xC2])
     locations = [0xCA7EE]
-    if not Options_.is_code_active('notawaiter'):
+    if not Options_.is_flag_active('notawaiter'):
         locations.append(0xCA2F0)
     for location in locations:
         nowhere_to_run_bottom_sub.set_location(location)
@@ -4642,7 +4642,7 @@ def manage_spookiness():
 
 
 def manage_dances():
-    if Options_.is_code_active('madworld'):
+    if Options_.is_flag_active('madworld'):
         spells = get_ranked_spells(sourcefile)
         dances = random.sample(spells, 32)
         dances = [s.spellid for s in dances]
@@ -4778,7 +4778,7 @@ def manage_cursed_encounters(formations: List[Formation], fsets: List[FormationS
     #print("SALT FORMATIONS: " + str(salt_formations))
 
     for fset in fsets:
-        if Options_.is_code_active("cursedencounters"): #code that applies FC flag to allow 16 encounters in all zones
+        if Options_.is_flag_active("cursedencounters"): #code that applies FC flag to allow 16 encounters in all zones
             if fset.setid < 252 or fset.setid in good_event_fsets: #only do regular enemies, don't do sets that can risk Zone Eater or get event encounters
                 if not [value for value in fset.formids if
                         value in event_formations]:
@@ -5095,7 +5095,7 @@ def randomize(**kwargs) -> str:
                             mode_num = i
                             break
             mode = ALL_MODES[mode_num]
-            allowed_flags = [f for f in NORMAL_CODES if f.category == "flags" and f.name not in mode.prohibited_flags]
+            allowed_flags = [f for f in NORMAL_FLAGS if f.category == "flags" and f.name not in mode.prohibited_flags]
             print()
             for flag in sorted(allowed_flags, key=lambda f: f.name):
                 print(flag.name, " - ", flag.long_description)
@@ -5199,7 +5199,7 @@ def randomize(**kwargs) -> str:
               "This seed will not produce the expected result!")
     s = "Using seed: %s|%s|%s|%s" % (VERSION,
                                      Options_.mode.name,
-                                     " ".join(Options_.active_codes.keys()),
+                                     " ".join(Options_.active_flags.keys()),
                                      seed)
     log(s, section=None)
     log("This is a game guide generated for the Beyond Chaos CE FF6 Randomizer.",
@@ -5215,16 +5215,16 @@ def randomize(**kwargs) -> str:
 
     tm = gmtime(seed)
     if tm.tm_mon == 12 and (tm.tm_mday == 24 or tm.tm_mday == 25):
-        Options_.activate_code('christmas')
+        Options_.activate_flag('christmas')
         activation_string += "CHRISTMAS MODE ACTIVATED\n"
     elif tm.tm_mon == 10 and tm.tm_mday == 31:
-        Options_.activate_code('halloween')
+        Options_.activate_flag('halloween')
         activation_string += "ALL HALLOWS' EVE MODE ACTIVATED\n"
 
     print(activation_string)
 
-    if Options_.is_code_active('randomboost'):
-        random_boost_value = Options_.get_code_value('randomboost')
+    if Options_.is_flag_active('randomboost'):
+        random_boost_value = Options_.get_flag_value('randomboost')
         if type(random_boost_value) == bool:
             while True:
                 random_boost_value = input("Please enter a randomness "
@@ -5238,7 +5238,7 @@ def randomize(**kwargs) -> str:
             set_randomness_multiplier(None)
         else:
             set_randomness_multiplier(int(random_boost_value))
-    elif Options_.is_code_active('madworld'):
+    elif Options_.is_flag_active('madworld'):
         set_randomness_multiplier(None)
 
     fout = open(outfile, "r+b")
@@ -5250,9 +5250,9 @@ def randomize(**kwargs) -> str:
 
     rng = Random(seed)
 
-    if Options_.is_code_active("thescenarionottaken"):
-        if Options_.is_code_active("strangejourney"):
-            print("thescenarionottaken code is incompatible with strangejourney")
+    if Options_.is_flag_active("thescenarionottaken"):
+        if Options_.is_flag_active("strangejourney"):
+            print("thescenarionottaken flag is incompatible with strangejourney")
         else:
             diverge(fout)
 
@@ -5261,25 +5261,25 @@ def randomize(**kwargs) -> str:
     relocate_ending_cinematic_data(fout, 0xF08A70)
 
     if Options_.shuffle_commands or Options_.replace_commands or Options_.random_treasure:
-        auto_recruit_gau(stays_in_wor=not Options_.shuffle_wor and not Options_.is_code_active('mimetime'))
+        auto_recruit_gau(stays_in_wor=not Options_.shuffle_wor and not Options_.is_flag_active('mimetime'))
         if Options_.shuffle_commands or Options_.replace_commands:
             auto_learn_rage()
 
-    if Options_.shuffle_commands and not Options_.is_code_active('suplexwrecks'):
+    if Options_.shuffle_commands and not Options_.is_flag_active('suplexwrecks'):
         manage_commands(commands)
         improve_gogo_status_menu(fout)
     reseed()
 
     spells = get_ranked_spells(sourcefile)
-    if Options_.is_code_active('madworld'):
+    if Options_.is_flag_active('madworld'):
         random.shuffle(spells)
         for i, s in enumerate(spells):
             s._rank = i + 1
             s.valid = True
-    if Options_.replace_commands and not Options_.is_code_active('suplexwrecks'):
-        if Options_.is_code_active('quikdraw'):
+    if Options_.replace_commands and not Options_.is_flag_active('suplexwrecks'):
+        if Options_.is_flag_active('quikdraw'):
             ALWAYS_REPLACE += ["rage"]
-        if Options_.is_code_active('sketch'):
+        if Options_.is_flag_active('sketch'):
             NEVER_REPLACE += ["sketch"]
         _, freespaces = manage_commands_new(commands)
         improve_gogo_status_menu(fout)
@@ -5295,7 +5295,7 @@ def randomize(**kwargs) -> str:
         randomize_final_party_order()
     reseed()
 
-    preserve_graphics = (not Options_.swap_sprites and not Options_.is_code_active('partyparty'))
+    preserve_graphics = (not Options_.swap_sprites and not Options_.is_flag_active('partyparty'))
 
     monsters = get_monsters(sourcefile)
     formations = get_formations(sourcefile)
@@ -5311,14 +5311,14 @@ def randomize(**kwargs) -> str:
         FreeBlock(0xFFFBE, 0xFFFBE + 66)
     ]
 
-    if Options_.random_final_dungeon or Options_.is_code_active('ancientcave'):
+    if Options_.random_final_dungeon or Options_.is_flag_active('ancientcave'):
         # do this before treasure
         if Options_.random_enemy_stats and Options_.random_treasure and Options_.random_character_stats:
             dirk = get_item(0)
             if dirk is None:
                 items = get_ranked_items(sourcefile)
                 dirk = get_item(0)
-            s = dirk.become_another(halloween=Options_.is_code_active('halloween'))
+            s = dirk.become_another(halloween=Options_.is_flag_active('halloween'))
             dirk.write_stats(fout)
             dummy_item(dirk)
             assert not dummy_item(dirk)
@@ -5360,7 +5360,7 @@ def randomize(**kwargs) -> str:
 
     if Options_.random_enemy_stats or Options_.shuffle_commands or Options_.replace_commands:
         for m in monsters:
-            m.screw_tutorial_bosses(old_vargas_fight=Options_.is_code_active('rushforpower'))
+            m.screw_tutorial_bosses(old_vargas_fight=Options_.is_flag_active('rushforpower'))
             m.write_stats(fout)
 
     # This needs to be before manage_monster_appearance or some of the monster
@@ -5375,7 +5375,7 @@ def randomize(**kwargs) -> str:
                                         preserve_graphics=preserve_graphics)
     reseed()
 
-    if Options_.random_palettes_and_names or Options_.swap_sprites or Options_.is_any_code_active(
+    if Options_.random_palettes_and_names or Options_.swap_sprites or Options_.is_any_flag_active(
             ['partyparty', 'bravenudeworld', 'suplexwrecks',
              'christmas', 'halloween', 'kupokupo', 'quikdraw', 'makeover']):
         s = manage_character_appearance(fout, preserve_graphics=preserve_graphics)
@@ -5390,8 +5390,8 @@ def randomize(**kwargs) -> str:
 
     esperrage_spaces = [FreeBlock(0x26469, 0x26469 + 919)]
     if Options_.random_espers:
-        if Options_.is_code_active('dancingmaduin'):
-            allocate_espers(Options_.is_code_active('ancientcave'), get_espers(sourcefile), get_characters(), fout,
+        if Options_.is_flag_active('dancingmaduin'):
+            allocate_espers(Options_.is_flag_active('ancientcave'), get_espers(sourcefile), get_characters(), fout,
                             esper_replacements)
             nerf_paladin_shield()
         manage_espers(esperrage_spaces, esper_replacements)
@@ -5420,7 +5420,7 @@ def randomize(**kwargs) -> str:
     savecheck_sub.write(fout)
     reseed()
 
-    if Options_.shuffle_commands and not Options_.is_code_active('suplexwrecks'):
+    if Options_.shuffle_commands and not Options_.is_flag_active('suplexwrecks'):
         # do this after swapping beserk
         manage_natural_magic()
     reseed()
@@ -5430,12 +5430,12 @@ def randomize(**kwargs) -> str:
         reset_rage_blizzard(items, umaro_risk, fout)
     reseed()
 
-    if Options_.shuffle_commands and not Options_.is_code_active('suplexwrecks'):
+    if Options_.shuffle_commands and not Options_.is_flag_active('suplexwrecks'):
         # do this after swapping beserk
         manage_tempchar_commands()
     reseed()
 
-    start_in_wor = Options_.is_code_active('worringtriad')
+    start_in_wor = Options_.is_flag_active('worringtriad')
     if Options_.random_character_stats:
         # do this after swapping berserk
         from itemrandomizer import set_item_changed_commands
@@ -5467,8 +5467,8 @@ def randomize(**kwargs) -> str:
             c.mutate_stats(fout, start_in_wor, read_only=True)
     reseed()
 
-    if Options_.is_code_active('mpboost'):
-        mp_boost_value = Options_.get_code_value('mpboost')
+    if Options_.is_flag_active('mpboost'):
+        mp_boost_value = Options_.get_flag_value('mpboost')
         if type(mp_boost_value) == bool:
             while True:
                 try:
@@ -5482,7 +5482,7 @@ def randomize(**kwargs) -> str:
     if Options_.random_formations:
         formations = get_formations()
         fsets = get_fsets()
-        if Options_.is_code_active('mpboost'):
+        if Options_.is_flag_active('mpboost'):
             manage_formations(formations, fsets, mp_boost_value)
             manage_cursed_encounters(formations, fsets)
         else:
@@ -5491,11 +5491,11 @@ def randomize(**kwargs) -> str:
         for fset in fsets:
             fset.write_data(fout)
 
-    if Options_.random_formations or Options_.is_code_active('ancientcave'):
+    if Options_.random_formations or Options_.is_flag_active('ancientcave'):
         manage_dragons()
     reseed()
 
-    if Options_.randomize_forest and not Options_.is_code_active('ancientcave') and not Options_.is_code_active(
+    if Options_.randomize_forest and not Options_.is_flag_active('ancientcave') and not Options_.is_flag_active(
             'strangejourney'):
         randomize_forest()
 
@@ -5507,11 +5507,11 @@ def randomize(**kwargs) -> str:
 
     reseed()
 
-    if Options_.random_final_dungeon and not Options_.is_code_active('ancientcave'):
+    if Options_.random_final_dungeon and not Options_.is_flag_active('ancientcave'):
         # do this before treasure
         manage_tower()
     reseed()
-    if Options_.is_code_active("norng"):
+    if Options_.is_flag_active("norng"):
         fix_norng_npcs()
 
     if Options_.random_formations or Options_.random_treasure:
@@ -5519,7 +5519,7 @@ def randomize(**kwargs) -> str:
 
     form_music = {}
     if Options_.random_formations:
-        no_special_events = not Options_.is_code_active('bsiab')
+        no_special_events = not Options_.is_flag_active('bsiab')
         manage_formations_hidden(formations, freespaces=aispaces, form_music_overrides=form_music,
                                      no_special_events=no_special_events)
         for m in get_monsters():
@@ -5541,12 +5541,12 @@ def randomize(**kwargs) -> str:
         # do this after hidden formations
         katn = Options_.mode.name == 'katn'
         manage_treasure(monsters, shops=True, no_charm_drops=katn, katnFlag=katn)
-        if not Options_.is_code_active('ancientcave'):
+        if not Options_.is_flag_active('ancientcave'):
             manage_chests()
-            mutate_event_items(fout, cutscene_skip=Options_.is_code_active('notawaiter'),
-                               crazy_prices=Options_.is_code_active('madworld'),
-                               no_monsters=Options_.is_code_active('nomiabs'),
-                               uncapped_monsters=Options_.is_code_active('bsiab'))
+            mutate_event_items(fout, cutscene_skip=Options_.is_flag_active('notawaiter'),
+                               crazy_prices=Options_.is_flag_active('madworld'),
+                               no_monsters=Options_.is_flag_active('nomiabs'),
+                               uncapped_monsters=Options_.is_flag_active('bsiab'))
             for fs in fsets:
                 # write new formation sets for MiaBs
                 fs.write_data(fout)
@@ -5557,7 +5557,7 @@ def randomize(**kwargs) -> str:
         # could probably do it after if I wasn't lazy
         manage_colorize_dungeons()
 
-    if Options_.is_code_active('ancientcave'):
+    if Options_.is_flag_active('ancientcave'):
         manage_ancient(Options_, fout, sourcefile, form_music_overrides=form_music, randlog=randlog)
     reseed()
 
@@ -5570,7 +5570,7 @@ def randomize(**kwargs) -> str:
             manage_blitz()
     reseed()
 
-    if Options_.is_code_active('halloween'):
+    if Options_.is_flag_active('halloween'):
         demon_chocobo_sub = Substitution()
         fout.seek(0x2d0000 + 896 * 7)
         demon_chocobo_sub.bytestring = fout.read(896)
@@ -5578,7 +5578,7 @@ def randomize(**kwargs) -> str:
             demon_chocobo_sub.set_location(0x2d0000 + 896 * i)
             demon_chocobo_sub.write(fout)
 
-    if Options_.random_window or Options_.is_code_active('christmas') or Options_.is_code_active('halloween'):
+    if Options_.random_window or Options_.is_flag_active('christmas') or Options_.is_flag_active('halloween'):
         for i in range(8):
             w = WindowBlock(i)
             w.read_data(sourcefile)
@@ -5586,8 +5586,8 @@ def randomize(**kwargs) -> str:
             w.write_data(fout)
     reseed()
 
-    if Options_.is_code_active('dearestmolulu') or (
-            Options_.random_formations and Options_.fix_exploits and not Options_.is_code_active('ancientcave')):
+    if Options_.is_flag_active('dearestmolulu') or (
+            Options_.random_formations and Options_.fix_exploits and not Options_.is_flag_active('ancientcave')):
         manage_encounter_rate()
     reseed()
     reseed()
@@ -5596,23 +5596,23 @@ def randomize(**kwargs) -> str:
         manage_colorize_animations()
     reseed()
 
-    if Options_.is_code_active('suplexwrecks'):
+    if Options_.is_flag_active('suplexwrecks'):
         manage_suplex(commands, monsters)
     reseed()
 
-    if Options_.is_code_active('strangejourney') and not Options_.is_code_active('ancientcave'):
+    if Options_.is_flag_active('strangejourney') and not Options_.is_flag_active('ancientcave'):
         create_dimensional_vortex()
         #manage_strange_events()
     reseed()
 
-    if Options_.is_code_active('notawaiter') and not Options_.is_code_active('ancientcave'):
+    if Options_.is_flag_active('notawaiter') and not Options_.is_flag_active('ancientcave'):
         print("Cutscenes are currently skipped up to Kefka @ Narshe")
         manage_skips()
     reseed()
 
     wor_free_char = 0xB  # gau
-    alternate_gogo = Options_.is_code_active('mimetime')
-    if (Options_.shuffle_wor or alternate_gogo) and not Options_.is_code_active('ancientcave'):
+    alternate_gogo = Options_.is_flag_active('mimetime')
+    if (Options_.shuffle_wor or alternate_gogo) and not Options_.is_flag_active('ancientcave'):
         include_gau = Options_.shuffle_commands or Options_.replace_commands or Options_.random_treasure
         wor_free_char = manage_wor_recruitment(fout,
                                                shuffle_wor=Options_.shuffle_wor,
@@ -5621,14 +5621,14 @@ def randomize(**kwargs) -> str:
                                                alternate_gogo=alternate_gogo)
     reseed()
 
-    if Options_.is_code_active('worringtriad') and not Options_.is_code_active('ancientcave'):
-        manage_wor_skip(fout, wor_free_char, airship=Options_.is_code_active('airship'),
+    if Options_.is_flag_active('worringtriad') and not Options_.is_flag_active('ancientcave'):
+        manage_wor_skip(fout, wor_free_char, airship=Options_.is_flag_active('airship'),
                         dragon=Options_.mode.name == 'dragonhunt',
-                        alternate_gogo=Options_.is_code_active('mimetime'),
+                        alternate_gogo=Options_.is_flag_active('mimetime'),
                         esper_replacements=esper_replacements)
     reseed()
 
-    if Options_.random_clock and not Options_.is_code_active('ancientcave'):
+    if Options_.random_clock and not Options_.is_flag_active('ancientcave'):
         manage_clock()
     reseed()
 
@@ -5638,7 +5638,7 @@ def randomize(**kwargs) -> str:
             improve_dance_menu(fout)
     reseed()
 
-    if Options_.is_code_active('remonsterate'):
+    if Options_.is_flag_active('remonsterate'):
         fout.close()
         backup_path = outfile[:outfile.rindex('.')] + '.backup' + outfile[outfile.rindex('.'):]
         copyfile(src=outfile, dst=backup_path)
@@ -5689,7 +5689,7 @@ def randomize(**kwargs) -> str:
             for result in remonsterate_results:
                 log(str(result) + '\n', section='remonsterate')
 
-    if not Options_.is_code_active('sketch') or Options_.is_code_active('remonsterate'):
+    if not Options_.is_flag_active('sketch') or Options_.is_flag_active('remonsterate'):
 
         #Original C2 sketch fix by Assassin, prevents bad pointers
 
@@ -5741,11 +5741,11 @@ def randomize(**kwargs) -> str:
              0x0A, 0x0A, 0x0A, 0x7B, 0x2A, 0x8D, 0xAB, 0x81, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA,])
         sketch_fix_sub.write(fout)
 
-    has_music = Options_.is_any_code_active(['johnnydmad', 'johnnyachaotic'])
+    has_music = Options_.is_any_flag_active(['johnnydmad', 'johnnyachaotic'])
     if has_music:
         music_init()
 
-    if Options_.is_code_active('alasdraco'):
+    if Options_.is_flag_active('alasdraco'):
         opera = manage_opera(fout, has_music)
         log(get_opera_log(), section="aesthetics")
     else:
@@ -5763,7 +5763,7 @@ def randomize(**kwargs) -> str:
     reseed()
 
     if Options_.random_enemy_stats or Options_.random_formations:
-        if not Options_.is_code_active('ancientcave') or Options_.mode.name == "katn":
+        if not Options_.is_flag_active('ancientcave') or Options_.mode.name == "katn":
             house_hint()
     reseed()
     reseed()
@@ -5772,11 +5772,11 @@ def randomize(**kwargs) -> str:
     randomize_passwords()
     reseed()
     namingway()
-    if Options_.is_code_active('thescenarionottaken'):
+    if Options_.is_flag_active('thescenarionottaken'):
         chocobo_merchant()
 
     # ----- NO MORE RANDOMNESS PAST THIS LINE -----
-    if Options_.is_code_active('thescenarionottaken'):
+    if Options_.is_flag_active('thescenarionottaken'):
         no_kutan_skip(fout)
 
     write_all_locations_misc()
@@ -5786,15 +5786,15 @@ def randomize(**kwargs) -> str:
     # This needs to be after write_all_locations_misc()
     # so the changes to Daryl don't get stomped.
     event_freespaces = [FreeBlock(0xCFE2A, 0xCFE2a + 470)]
-    if Options_.is_code_active('airship'):
+    if Options_.is_flag_active('airship'):
         event_freespaces = activate_airship_mode(event_freespaces)
 
     if Options_.random_zerker or Options_.random_character_stats:
         manage_equip_umaro(event_freespaces)
 
-    if Options_.is_code_active('easymodo') or Options_.is_code_active('expboost'):
-        exp_boost_value = Options_.get_code_value('expboost')
-        if Options_.is_code_active('expboost') and type(exp_boost_value) == bool:
+    if Options_.is_flag_active('easymodo') or Options_.is_flag_active('expboost'):
+        exp_boost_value = Options_.get_flag_value('expboost')
+        if Options_.is_flag_active('expboost') and type(exp_boost_value) == bool:
             while True:
                 try:
                     exp_boost_value = float(input("Please enter an EXP multiplier value (0.0-50.0): "))
@@ -5804,14 +5804,14 @@ def randomize(**kwargs) -> str:
                 except ValueError:
                     print("The supplied value for the EXP multiplier was not a positive number.")
         for m in monsters:
-            if Options_.is_code_active('easymodo'):
+            if Options_.is_flag_active('easymodo'):
                 m.stats['hp'] = 1
             if exp_boost_value:
                 m.stats['xp'] = int(min(0xFFFF, float(exp_boost_value) * m.stats['xp']))
             m.write_stats(fout)
 
-    if Options_.is_code_active('gpboost'):
-        gp_boost_value = Options_.get_code_value('gpboost')
+    if Options_.is_flag_active('gpboost'):
+        gp_boost_value = Options_.get_flag_value('gpboost')
         if type(gp_boost_value) == bool:
             while True:
                 try:
@@ -5825,12 +5825,12 @@ def randomize(**kwargs) -> str:
             m.stats['gpboost'] = int(min(0xFFFF, float(gp_boost_value) * m.stats['gp']))
             m.write_stats(fout)
 
-    if Options_.is_code_active('naturalmagic') or Options_.is_code_active('naturalstats'):
+    if Options_.is_flag_active('naturalmagic') or Options_.is_flag_active('naturalstats'):
         espers = get_espers(sourcefile)
-        if Options_.is_code_active('naturalstats'):
+        if Options_.is_flag_active('naturalstats'):
             for e in espers:
                 e.bonus = 0xFF
-        if Options_.is_code_active('naturalmagic'):
+        if Options_.is_flag_active('naturalmagic'):
             for e in espers:
                 e.spells, e.learnrates = [], []
             for i in items:
@@ -5840,16 +5840,16 @@ def randomize(**kwargs) -> str:
         for e in espers:
             e.write_data(fout)
 
-    if Options_.is_code_active('canttouchthis'):
+    if Options_.is_flag_active('canttouchthis'):
         for c in characters:
             if c.id >= 14:
                 continue
             c.become_invincible(fout)
 
-    if Options_.is_code_active('equipanything'):
+    if Options_.is_flag_active('equipanything'):
         manage_equip_anything()
 
-    if Options_.is_code_active('playsitself'):
+    if Options_.is_flag_active('playsitself'):
         manage_full_umaro()
         for c in commands.values():
             if c.id not in [0x01, 0x08, 0x0E, 0x0F, 0x15, 0x19]:
@@ -5865,12 +5865,12 @@ def randomize(**kwargs) -> str:
         if item.banned:
             assert not dummy_item(item)
 
-    if Options_.is_code_active('christmas') and not Options_.is_code_active('ancientcave'):
+    if Options_.is_flag_active('christmas') and not Options_.is_flag_active('ancientcave'):
         manage_santa()
-    elif Options_.is_code_active('halloween') and not Options_.is_code_active('ancientcave'):
+    elif Options_.is_flag_active('halloween') and not Options_.is_flag_active('ancientcave'):
         manage_spookiness()
 
-    if Options_.is_code_active('dancelessons'):
+    if Options_.is_flag_active('dancelessons'):
         no_dance_stumbles(fout)
 
     banon_life3(fout)
@@ -5884,8 +5884,8 @@ def randomize(**kwargs) -> str:
     improved_party_gear(fout)
     manage_doom_gaze(fout)
 
-    if Options_.is_code_active("swdtechspeed"):
-        swdtech_speed = Options_.get_code_value('swdtechspeed')
+    if Options_.is_flag_active("swdtechspeed"):
+        swdtech_speed = Options_.get_flag_value('swdtechspeed')
         if type(swdtech_speed) == bool:
             while True:
                 swdtech_speed = input("\nPlease enter a custom speed for Sword Tech " 
@@ -5897,8 +5897,8 @@ def randomize(**kwargs) -> str:
                 except ValueError:
                     print("The supplied speed was not a valid option. Please try again.")
         change_swdtech_speed(fout, random, swdtech_speed)
-    if Options_.is_code_active("cursepower"):
-        change_cursed_shield_battles(fout, random, Options_.get_code_value("cursepower"))
+    if Options_.is_flag_active("cursepower"):
+        change_cursed_shield_battles(fout, random, Options_.get_flag_value("cursepower"))
 
     s = manage_coral(fout)
     log(s, "aesthetics")
@@ -5906,13 +5906,13 @@ def randomize(**kwargs) -> str:
     # TODO Does not work currently - needs fixing to allow Lenophis' esper bonus patch to work correctly
     # add_esper_bonuses(fout)
 
-    if Options_.is_code_active('removeflashing'):
+    if Options_.is_flag_active('removeflashing'):
         fewer_flashes(fout)
 
-    if Options_.is_code_active('nicerpoison'):
+    if Options_.is_flag_active('nicerpoison'):
         nicer_poison(fout)
 
-    if not Options_.is_code_active('fightclub'):
+    if not Options_.is_flag_active('fightclub'):
         show_coliseum_rewards(fout)
 
     if Options_.replace_commands or Options_.shuffle_commands:
@@ -5951,7 +5951,7 @@ def randomize(**kwargs) -> str:
             log(m.get_description(changed_commands=changed_commands),
                 section="monsters")
 
-    if not Options_.is_code_active("ancientcave"):
+    if not Options_.is_flag_active("ancientcave"):
         log_chests()
     log_item_mutations()
 
@@ -5964,7 +5964,7 @@ def randomize(**kwargs) -> str:
 
     print("Randomization successful. Output filename: %s\n" % outfile)
 
-    if Options_.is_code_active('bingoboingo'):
+    if Options_.is_flag_active('bingoboingo'):
 
         target_score = 200.0
 
@@ -6032,10 +6032,12 @@ if __name__ == "__main__":
             '\t\tsource=<file path to your unrandomized Final Fantasy 3 v1.0 ROM file>\n',
             '\t\tdestination=<directory path where you want the randomized ROM and spoiler log created>\n',
             '\t\tseed=<flag and seed information in the format version.mode.flags.seed>\n'
-            '\t\tbingotype=<The desired bingo options, if you are using the bingoboingo code>\n',
-            '\t\tbingosize=<The desired positive integer for the size of bingo card, if you are using the bingoboingo code>\n',
-            '\t\tbingodifficulty=<The desired bingo difficulty selection, if you are using the bingoboingo code>\n',
-            '\t\tbingocards=<The desired positive integer for number of bingo cards to generate, if you are using the bingoboingo code>\n',
+            '\t\tbingotype=<The desired bingo options, if you are using the bingoboingo flag>\n',
+            '\t\tbingosize=<The desired positive integer for the size of bingo card, '
+            'if you are using the bingoboingo flag>\n',
+            '\t\tbingodifficulty=<The desired bingo difficulty selection, if you are using the bingoboingo flag>\n',
+            '\t\tbingocards=<The desired positive integer for number of bingo cards to generate, '
+            'if you are using the bingoboingo flag>\n',
 
         )
         sys.exit()

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -44,7 +44,7 @@ from monsterrandomizer import (REPLACE_ENEMIES, MonsterGraphicBlock, get_monster
                                change_enemy_name, randomize_enemy_name,
                                get_collapsing_house_help_skill)
 from musicinterface import randomize_music, manage_opera, get_music_spoiler, music_init, get_opera_log
-from options import ALL_MODES, ALL_FLAGS, Options_
+from options import ALL_MODES, NORMAL_CODES, Options_
 from patches import (allergic_dog, banon_life3, vanish_doom, evade_mblock,
                      death_abuse, no_kutan_skip, show_coliseum_rewards,
                      cycle_statuses, no_dance_stumbles, fewer_flashes,
@@ -4108,7 +4108,7 @@ def manage_opening():
 
     from string import ascii_letters as alpha
     consonants = "".join([c for c in alpha if c not in "aeiouy"])
-    flag_names = [f.name for f in Options_.active_flags]
+    flag_names = [f for f in Options_.active_codes.keys() if len(f) == 1]
     display_flags = sorted([a for a in alpha if a in flag_names])
     text = "".join([consonants[int(i)] for i in str(seed)])
     codestatus = "CODES ON" if Options_.active_codes else "CODES OFF"
@@ -4981,10 +4981,6 @@ def randomize(**kwargs) -> str:
     global outfile, sourcefile, flags, seed, fout, ALWAYS_REPLACE, NEVER_REPLACE
 
     if TEST_ON:
-        # while len(args) < 3:
-        #    args.append(None)
-        # args[1] = TEST_FILE
-        # args[2] = TEST_SEED
         kwargs['sourcefile'] = TEST_FILE
         kwargs['seed'] = TEST_SEED
     sleep(0.5)
@@ -4996,22 +4992,9 @@ def randomize(**kwargs) -> str:
     previous_output_directory = ''
 
     sourcefile = kwargs.get('sourcefile')
-    # if len(args) > 2:
-    # sourcefile = args[1].strip()
-    # else:
     if not sourcefile:
         previous_rom_path = get_input_path()
         previous_output_directory = get_output_path()
-        # try:
-        #     config = configparser.ConfigParser()
-        #     config.read('bcce.cfg')
-        #     if 'ROM' in config:
-        #         previous_rom_path = config['ROM']['Path']
-        #         previous_output_directory = config['ROM']['Output']
-        # except (IOError, KeyError) as e:
-        #     print(str(e))
-        #     pass
-
         previous_input = f" (blank for default: {previous_rom_path})" if previous_rom_path else ""
         sourcefile = input(f"Please input the file name of your copy of "
                            f"the FF3 US 1.0 rom{previous_input}:\n> ").strip()
@@ -5027,10 +5010,6 @@ def randomize(**kwargs) -> str:
     sourcefile = os.path.abspath(sourcefile)
 
     output_directory = kwargs.get('output_directory')
-    # if len(args) > 4:
-    # If a directory was supplied by the GUI, use that directory
-    # output_directory = args[4]
-    # else:
     if not output_directory:
         # If no previous directory or an invalid directory was obtained from bcce.cfg, default to the ROM's directory
         if not previous_output_directory or not os.path.isdir(os.path.normpath(previous_output_directory)):
@@ -5092,11 +5071,7 @@ def randomize(**kwargs) -> str:
     flaghelptext = '''!   Recommended new player flags
 -   Use all flags EXCEPT the ones listed'''
 
-    #speeddial_opts = {}
-
     fullseed = kwargs.get('seed')
-    # if len(args) > 2:
-    # fullseed = args[2].strip()
     if fullseed:
         fullseed = str(fullseed).strip()
     else:
@@ -5120,10 +5095,10 @@ def randomize(**kwargs) -> str:
                             mode_num = i
                             break
             mode = ALL_MODES[mode_num]
-            allowed_flags = [f for f in ALL_FLAGS if f.name not in mode.prohibited_flags]
+            allowed_flags = [f for f in NORMAL_CODES if f.category == "flags" and f.name not in mode.prohibited_flags]
             print()
-            for flag in sorted(allowed_flags):
-                print(flag.name, flag.description)
+            for flag in sorted(allowed_flags, key=lambda f: f.name):
+                print(flag.name, " - ", flag.long_description)
             print(flaghelptext + "\n")
             print("Save frequently used flag sets by adding 0: through 9: before the flags.")
             for speeddial_number, speeddial_flags in speeddials:
@@ -5131,7 +5106,7 @@ def randomize(**kwargs) -> str:
             print()
             flags = input("Please input your desired flags (blank for "
                           "all of them):\n> ").strip()
-            if flags == "!" :
+            if flags == "!":
                 flags = '-dfklu partyparty makeover johnnydmad'
 
             is_speeddialing = re.search("^[0-9]$", flags)
@@ -5167,7 +5142,6 @@ def randomize(**kwargs) -> str:
     if mode_num not in range(len(ALL_MODES)):
         raise Exception("Invalid mode specified")
     Options_.mode = ALL_MODES[mode_num]
-    allowed_flags = [f for f in ALL_FLAGS if f.name not in Options_.mode.prohibited_flags]
 
     seed = seed.strip()
     if not seed:
@@ -5195,31 +5169,8 @@ def randomize(**kwargs) -> str:
         try:
             save_input_path(sourcefile)
             save_output_path(output_directory)
-
-            # config = configparser.ConfigParser()
-            # config.read('bcce.cfg')
-            # if 'ROM' not in config:
-            #     config['ROM'] = {}
-            # if 'speeddial' not in config:
-            #     config['speeddial'] = {}
-            # config['ROM']['Path'] = sourcefile
-
-            # # Save the output directory
-            # if str(output_directory).lower() == str(os.path.dirname(sourcefile)).lower():
-            #     # If the output directory is the same as the ROM directory, save an empty string
-            #     config['ROM']['Output'] = ''
-            # else:
-            #     config['ROM']['Output'] = output_directory
-            # #config['speeddial'].update({k: v for k, v in speeddial_opts.items() if k != '!'})
-            # with open('bcce.cfg', 'w') as cfg_file:
-            #     config.write(cfg_file)
         except:
             print("Couldn't save flag string\n")
-        # else:
-        #     try:
-        #         os.remove('savedflags.txt')
-        #     except OSError:
-        #         pass
 
     if len(data) % 0x400 == 0x200:
         print("NOTICE: Headered ROM detected. Output file will have no header.")
@@ -5241,21 +5192,15 @@ def randomize(**kwargs) -> str:
     copyfile(sourcefile, outfile)
 
     flags = flags.lower()
-    # flags = flags.replace('endless9', 'endless~nine~')
-    # for d in "!0123456789":
-    #    if d in speeddial_opts:
-    #        replacement = speeddial_opts[d]
-    #    else:
-    #        replacement = ''
-    #    flags = flags.replace(d, replacement)
-    #    flags = flags.replace('endless9', 'endless~nine~')
-    # flags = flags.replace('endless~nine~', 'endless9')
+    activation_string = Options_.activate_from_string(flags)
 
     if version and version != VERSION:
         print("WARNING! Version mismatch! "
               "This seed will not produce the expected result!")
-    s = "Using seed: %s|%s|%s|%s" % (VERSION, Options_.mode.name, flags, seed)
-    print(s)
+    s = "Using seed: %s|%s|%s|%s" % (VERSION,
+                                     Options_.mode.name,
+                                     " ".join(Options_.active_codes.keys()),
+                                     seed)
     log(s, section=None)
     log("This is a game guide generated for the Beyond Chaos CE FF6 Randomizer.",
         section=None)
@@ -5267,8 +5212,6 @@ def randomize(**kwargs) -> str:
 
     character.load_characters(original_rom_location, force_reload=True)
     characters = get_characters()
-
-    activation_string = Options_.activate_from_string(flags)
 
     tm = gmtime(seed)
     if tm.tm_mon == 12 and (tm.tm_mday == 24 or tm.tm_mday == 25):

--- a/BeyondChaos/randomizers/characterstats.py
+++ b/BeyondChaos/randomizers/characterstats.py
@@ -10,7 +10,7 @@ class CharacterStats(Randomizer):
 
     def __init__(self, rng: random.Random, options: Options, characters: List[Character]):
         super().__init__(options)
-        self._randomize_level = not self._Options.is_code_active('worringtriad')
+        self._randomize_level = not self._Options.is_flag_active('worringtriad')
         self._characters = characters
         self._rng = rng
 

--- a/BeyondChaos/towerrandomizer.py
+++ b/BeyondChaos/towerrandomizer.py
@@ -308,7 +308,7 @@ def remap_maps(routes):
             if loc.locid not in towerlocids:
                 loc.make_tower_flair()
                 from options import Options_
-                loc.unlock_chests(200, 1000, uncapped_monsters=Options_.is_code_active('bsiab'))
+                loc.unlock_chests(200, 1000, uncapped_monsters=Options_.is_flag_active('bsiab'))
                 fsets = get_new_fsets("kefka's tower", 20)
                 fset = random.choice(fsets)
                 for formation in fset.formations:


### PR DESCRIPTION
Note: This change may be controversial.

Flag objects have been converted into Code objects, because they were essentially the same thing. Now, instead of having two types of objects with different attributes and different methods, we just have one type of object. I intend to also change references to "codes" into "flags", because "flags" are more common randomizer vernacular.

randomizer.py:
- Removed old commented out code.
- Adjusted the code previously looking at Flags to now look at Codes with a code.name length of 1.
- Moved the call for Options_.activate_from_string up in the code slightly and then modified the 'Using seed' logfile entry such that it outputs the currently active codes. The result is that when somebody inverts the basic flag selection using '-', the log file will display the actual codes used instead of the codes the user typed. For example, previously the log would say '-u' if the user typed '-u'. Now it will say 'b c d e f g h i j k l m n o p q r s t w y z'.

options.py:
- Added import to re (regex library)
- Added additional attributes to the Code class: default_index, default_value, minimum_value, maximum_value. These additional attributes should make it easier to configure a GUI.
- Modified remove_from_string() method to process the simple flags. The method now uses regexes to exactly match code names, allowing it to distinguish the d in the 'd' flag from the d's in 'swdtechspeed'. Also moved prohibited_codes detection from activate_from_string() into remove_from_string().
- Commented out a couple of unused methods.
- Commented out flag-related code that is no longer used.
- Renamed 'numberbox' inputtypes to 'float2' (float with 2 decimal places) or 'integer', as appropriate

beyondchaos.py:
- Adjusted the controls for QDoubleSpinBox and QSpinBox to use the new inputtypes of 'float2' and 'integer'. The adjusted controls use the new default_value and minimum_values in some places. WIP.
- Added a code category for "flags" under initCodes, letting the GUI populate with the new Code-based basic flags.
- Previously, the dictionary of code names had attributes for explanation, inputtype, checked, and choices. I adjusted this to have two attributes, one for checked, and one for object, which is a reference to the Code object. Accessing the object allows us to get the description, inputtype, choices, and many more attributes. Code lines referencing the old attributes were updated to reference the attributes in the object.