### PR TITLE
Fix for encoding error when opening shorttext.txt.

### DIFF
--- a/BeyondChaos/utils.py
+++ b/BeyondChaos/utils.py
@@ -178,7 +178,7 @@ def name_to_bytes(name, length):
 
 shorttexttable = {}
 try:
-    f = open(SHORT_TEXT_TABLE)
+    f = open(SHORT_TEXT_TABLE, encoding="utf-8")
     for line in f:
         line = line.strip()
         char, value = tuple(line.split())


### PR DESCRIPTION
- Specified that the encoding should be utf-8