### PR TITLE
Junction update + MP damage color patch

### DIFF
--- a/BeyondChaos/patches.py
+++ b/BeyondChaos/patches.py
@@ -1,6 +1,14 @@
-from utils import Substitution, RANDOM_MULTIPLIER, MYSELF_BLOB, random
-from character import get_characters
 from io import BytesIO
+import os
+
+from bcg_junction import (write_patch as jm_write_patch,
+                          tblpath as jm_tblpath,
+                          verify_patchlist as jm_verify_patchlist)
+from character import get_characters
+from utils import Substitution, RANDOM_MULTIPLIER, random
+
+
+JM_PATCHLIST = set()
 
 
 def allergic_dog(output_rom_buffer: BytesIO):
@@ -1774,3 +1782,26 @@ def fewer_flashes(output_rom_buffer: BytesIO, flag_value):
     # CC/D6FB - Blue Flash
     # CC/D713 - Blue Flash
     # CC/D720 - Blue Flash
+
+
+def vanish_doom(output_rom_buffer: BytesIO):
+    vanish_doom_patch = os.path.join(jm_tblpath, 'patch_vanish_doom.txt')
+    JM_PATCHLIST.add(vanish_doom_patch)
+    jm_write_patch(output_rom_buffer, vanish_doom_patch)
+
+
+def mp_color_digits(output_rom_buffer: BytesIO):
+    mp_patch = os.path.join(jm_tblpath, 'patch_mp_color_digits.txt')
+    JM_PATCHLIST.add(mp_patch)
+    jm_write_patch(output_rom_buffer, mp_patch)
+
+
+def can_always_access_esper_menu(output_rom_buffer: BytesIO):
+    enable_esper_menu_patch = os.path.join(
+        jm_tblpath, 'patch_can_always_access_esper_menu.txt')
+    JM_PATCHLIST.add(enable_esper_menu_patch)
+    jm_write_patch(output_rom_buffer, enable_esper_menu_patch)
+
+
+def verify_patchlist(output_rom_buffer: BytesIO):
+    jm_verify_patchlist(output_rom_buffer, sorted(JM_PATCHLIST))

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -18,8 +18,6 @@ from ancient import manage_ancient
 from appearance import manage_character_appearance, manage_coral
 from character import get_characters, get_character, equip_offsets, character_list, load_characters
 from bcg_junction import (JunctionManager,
-                          write_patch as jm_write_patch,
-                          tblpath as jm_tblpath,
                           set_addressing_mode as jm_set_addressing_mode)
 from chestrandomizer import mutate_event_items, get_event_items
 from config import (get_input_path, get_output_path, save_input_path, save_output_path, get_items,
@@ -47,11 +45,14 @@ from monsterrandomizer import (REPLACE_ENEMIES, MonsterGraphicBlock, get_monster
 from myselfpatches import myself_patches
 from musicinterface import randomize_music, manage_opera, get_music_spoiler, music_init, get_opera_log
 from options import ALL_MODES, NORMAL_FLAGS, Options_
-from patches import (allergic_dog, banon_life3, evade_mblock,
-                     death_abuse, no_kutan_skip, show_coliseum_rewards,
-                     cycle_statuses, no_dance_stumbles, fewer_flashes,
-                     change_swdtech_speed, change_cursed_shield_battles, sprint_shoes_break, title_gfx, apply_namingway,
-                     improved_party_gear, patch_doom_gaze, nicer_poison, fix_xzone, imp_skimp, hidden_relic, y_equip_relics, fix_gogo_portrait)
+from patches import (
+    allergic_dog, banon_life3, evade_mblock, death_abuse, no_kutan_skip,
+    show_coliseum_rewards, cycle_statuses, no_dance_stumbles, fewer_flashes,
+    change_swdtech_speed, change_cursed_shield_battles, sprint_shoes_break,
+    title_gfx, apply_namingway, improved_party_gear, patch_doom_gaze,
+    nicer_poison, fix_xzone, imp_skimp, hidden_relic, y_equip_relics,
+    fix_gogo_portrait, vanish_doom, mp_color_digits,
+    can_always_access_esper_menu, verify_patchlist)
 from shoprandomizer import (get_shops, buy_owned_breakable_tools)
 from sillyclowns import randomize_passwords, randomize_poem
 from skillrandomizer import (SpellBlock, CommandBlock, SpellSub, ComboSpellSub,
@@ -809,9 +810,7 @@ def manage_commands(commands: Dict[str, CommandBlock]):
     rage_blank_sub.set_location(0x47AA0)
     rage_blank_sub.write(outfile_rom_buffer)
 
-    enable_esper_menu_patch = os.path.join(
-        jm_tblpath, 'patch_can_always_access_esper_menu.txt')
-    jm_write_patch(outfile_rom_buffer, enable_esper_menu_patch)
+    can_always_access_esper_menu(outfile_rom_buffer)
 
     # Let x-magic user use magic menu.
     enable_xmagic_menu_sub = Substitution()
@@ -2186,8 +2185,7 @@ def manage_rng():
 
 
 def manage_balance(newslots: bool = True):
-    vanish_doom_patch = os.path.join(jm_tblpath, 'patch_vanish_doom.txt')
-    jm_write_patch(outfile_rom_buffer, vanish_doom_patch)
+    vanish_doom(outfile_rom_buffer)
     evade_mblock(outfile_rom_buffer)
     fix_xzone(outfile_rom_buffer)
     imp_skimp(outfile_rom_buffer)
@@ -6019,6 +6017,7 @@ def randomize(connection: Pipe = None, **kwargs) -> str:
     fix_flash_and_bioblaster(outfile_rom_buffer)
     title_gfx(outfile_rom_buffer)
     improved_party_gear(outfile_rom_buffer)
+    mp_color_digits(outfile_rom_buffer)
     manage_doom_gaze(outfile_rom_buffer)
 
     if Options_.is_flag_active("swdtechspeed"):
@@ -6086,6 +6085,7 @@ def randomize(connection: Pipe = None, **kwargs) -> str:
     rewrite_title(text="FF6 BCCE %s" % seed)
     validate_rom_expansion()
     rewrite_checksum()
+    verify_patchlist(outfile_rom_buffer)
 
     if not application or application != "web":
         with open(outfile_rom_path, 'wb+') as f:

--- a/BeyondChaos/randomtools/tablereader.py
+++ b/BeyondChaos/randomtools/tablereader.py
@@ -409,6 +409,16 @@ def patch_filename_to_bytecode(patchfilename, mapping=None, parameters=None):
             else:
                 next_address += 1
 
+    for defname in sorted(definitions):
+        for aname in sorted(code_addresses):
+            if defname in aname.lower():
+                raise Exception('Address "%s" cannot contain '
+                                'definition "%s".' % (aname, defname))
+        for lname in sorted(labels):
+            if defname in lname.lower():
+                raise Exception('Label "%s" cannot contain '
+                                'definition "%s".' % (lname, defname))
+
     for read_into in (patch, validation):
         for (address, filename) in sorted(read_into):
             code = read_into[address, filename]

--- a/BeyondChaos/randomtools/utils.py
+++ b/BeyondChaos/randomtools/utils.py
@@ -427,10 +427,10 @@ def get_snes_palette_transformer(use_luma=False, always=None, middle=True,
 
 def rewrite_snes_title(text, filename, version, lorom=False):
     f = open(filename, 'r+b')
-    while len(text) < 20:
+    while len(text) < 21:
         text += ' '
-    if len(text) > 20:
-        text = text[:19] + "?"
+    if len(text) > 21:
+        text = text[:20] + "?"
     if lorom:
         mask = 0x7FFF
     else:

--- a/BeyondChaos/tables/bcg_junction_manifest.json
+++ b/BeyondChaos/tables/bcg_junction_manifest.json
@@ -182,7 +182,9 @@
         "true_paladin":         "9e",
         "popular":              "9f",
         "gaia_boost":           "a0",
-        "gaia_assist":          "a1"
+        "gaia_assist":          "a1",
+        "flinch":               "a2",
+        "double_time":          "a3"
     },
 
     "junction_short_names": {
@@ -344,7 +346,9 @@
         "true_paladin":         "True Paladin",
         "popular":              "Popularity",
         "gaia_boost":           "Gaia Boost",
-        "gaia_assist":          "Gaia Assist"
+        "gaia_assist":          "Gaia Assist",
+        "flinch":               "Flinch",
+        "double_time":          "Double Time"
     },
 
     "junction_tags": {
@@ -506,7 +510,9 @@
         "true_paladin":         ["defend"],
         "popular":              ["defend"],
         "gaia_boost":           ["dance", "fire", "ice", "bolt", "poison", "wind", "pearl", "earth", "water"],
-        "gaia_assist":          ["dance", "defend", "magic"]
+        "gaia_assist":          ["dance", "defend", "magic"],
+        "flinch":               ["slow", "debuff"],
+        "double_time":          ["haste", "buff"]
     },
 
     "esper_tags":       "tags_esper.json",
@@ -787,10 +793,12 @@
             "patch_junction_focus.txt"
         ],
         "blood_mage": [
-            "patch_junction_gold_blood_mage.txt"
+            "patch_junction_gold_blood_mage.txt",
+            "patch_junction_prehit_trigger.txt"
         ],
         "gold_mage": [
-            "patch_junction_gold_blood_mage.txt"
+            "patch_junction_gold_blood_mage.txt",
+            "patch_junction_prehit_trigger.txt"
         ],
         "reflect_boost": [
             "patch_junction_reflect_boost.txt"
@@ -1116,13 +1124,16 @@
             "patch_junction_unlimited.txt"
         ],
         "mp_switch": [
-            "patch_junction_mp_switch.txt"
+            "patch_junction_mp_switch.txt",
+            "patch_junction_prehit_trigger.txt"
         ],
         "mp_regen": [
-            "patch_junction_mp_regen.txt"
+            "patch_junction_mp_regen.txt",
+            "patch_junction_prehit_trigger.txt"
         ],
         "astral": [
-            "patch_junction_hit_trigger.txt"
+            "patch_junction_hit_trigger.txt",
+            "patch_junction_prehit_trigger.txt"
         ],
         "vorpal": [
             "patch_junction_hit_trigger.txt"
@@ -1243,6 +1254,13 @@
         "gaia_assist": [
             "patch_junction_prehit_trigger.txt",
             "patch_junction_command_spell_proc.txt"
+        ],
+        "flinch": [
+            "patch_junction_prehit_trigger.txt"
+        ],
+        "double_time": [
+            "patch_junction_double_time.txt",
+            "patch_junction_damage_trigger.txt"
         ]
     }
 }

--- a/BeyondChaos/tables/patch_junction_caller.txt
+++ b/BeyondChaos/tables/patch_junction_caller.txt
@@ -33,7 +33,7 @@
 .addr   wide-bits                       00b4f3
 
 .def    jun-index           99
-.def    esper-order         0e 0d 07 13 0f 18 16 01 11 06 0b 09 14 1a 10 0c 00 02 05 03 15 19 08 04 0a 17 12 ff
+.def    esper-order-list    0e 0d 07 13 0f 18 16 01 11 06 0b 09 14 1a 10 0c 00 02 05 03 15 19 08 04 0a 17 12 ff
 .def    overflow-index      1c
 
 0182ad: ea ea
@@ -48,7 +48,7 @@
 025789: 22 $main-multicast
 :       ea
 
-$esper-order-address: esper-order
+$esper-order-address: esper-order-list
 
 $main-multicast
 :       48

--- a/BeyondChaos/tables/patch_junction_command_summon.txt
+++ b/BeyondChaos/tables/patch_junction_command_summon.txt
@@ -38,6 +38,7 @@ $main
 :       5c $reentry-address
 
 .label no-esper
+:       a9 ff
 :       85 b8
 :       5c $reentry-no-esper
 

--- a/BeyondChaos/tables/patch_junction_critical_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_critical_trigger.txt
@@ -5,9 +5,9 @@
 .addr   main                            620480
 
 .addr   spell-indexes-address           620580
-.def    spell-indexes           1f 21 22 26 2a 2b 2f 33 34 35 4c 4e fe cf
+.def    spell-indexes-list      1f 21 22 26 2a 2b 2f 33 34 35 4c 4e fe cf
 .addr   command-indexes-address         620590
-.def    command-indexes         0b 18 40 41 15
+.def    command-indexes-list    0b 18 40 41 15
 
 .def    first-spell-index           20
 .def    overflow-spell-index        2e
@@ -28,10 +28,10 @@
 :       ea ea
 
 $spell-indexes-address
-:       spell-indexes
+:       spell-indexes-list
 
 $command-indexes-address
-:       command-indexes
+:       command-indexes-list
 
 $main
 :       5d 05 32

--- a/BeyondChaos/tables/patch_junction_damage_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_damage_trigger.txt
@@ -8,7 +8,7 @@
 .addr   jun-set-target-allies           610780
 .addr   jun-count-bits                  6108c0
 .addr   main                            620c00
-.addr   main-nihopalaoa                 620c60
+.addr   main-nihopalaoa                 6210e0
 .addr   main-calc                       621dc0
 .addr   check-calc                      621c80
 .addr   do-distribute-characters        621d00
@@ -23,6 +23,7 @@
 .addr   boost-healing-quarter           620f60
 .addr   reduce-healing-quarter          620f80
 .addr   reduce-damage-half              620ce0
+.addr   reduce-healing-half             620cf0
 .addr   reverse-damage                  620fa0
 .addr   check-precision                 620fc0
 .addr   do-auto-potion                  621100
@@ -46,6 +47,7 @@
 .def    jun-index-auto-potion       80
 .def        jun-index-salve             07
 .def        potion-index                e9
+.def    jun-index-double-time       a3
 
 
 022af2: 22 $main-nihopalaoa
@@ -72,6 +74,13 @@ $main
 :       20 $check-brace,2
 :       20 $check-catch,2
 
+:       a9 jun-index-double-time 00
+:       22 $jun-checker
+:       f0 no-double-time
+:       20 $reduce-damage-half,2
+:       20 $reduce-healing-half,2
+
+.label no-double-time
 :       a5 b5
 :       29 ff 00
 :       c9 01 00
@@ -443,7 +452,7 @@ $check-catch
 $boost-healing-half
 :       b9 e4 33
 :       c9 ff ff
-:       f0 exit-healing-half
+:       f0 exit-boost-healing-half
 :       4a
 :       18
 :       79 e4 33
@@ -451,7 +460,7 @@ $boost-healing-half
 :       a9 fe ff
 .label healing-half-no-overflow
 :       99 e4 33
-.label exit-healing-half
+.label exit-boost-healing-half
 :       60
 
 $boost-healing-quarter
@@ -516,6 +525,15 @@ $reduce-damage-half
 :       4a
 :       99 d0 33
 .label exit-damage-half
+:       60
+
+$reduce-healing-half
+:       b9 e4 33
+:       c9 ff ff
+:       f0 exit-reduce-healing-half
+:       4a
+:       99 e4 33
+.label exit-reduce-healing-half
 :       60
 
 $check-nonzero-nonlethal-damage

--- a/BeyondChaos/tables/patch_junction_double_time.txt
+++ b/BeyondChaos/tables/patch_junction_double_time.txt
@@ -1,0 +1,27 @@
+.addr   jun-checker                     610000
+.addr   main                            620ba0
+
+.def    jun-index-double-time       a3
+
+0201be: 22 $main
+:       ea ea ea ea
+
+$main
+:       fe 19 32
+:       d0 check-double-time
+:       de 19 32
+:       6b
+.label check-double-time
+:       a9 jun-index-double-time
+:       22 $jun-checker
+:       f0 exit-main
+:       a9 80
+:       9d 19 32
+.label exit-main
+:       6b
+
+VALIDATION
+
+0201be: fe 19 32
+:       d0 03
+:       de 19 32

--- a/BeyondChaos/tables/patch_junction_focus.txt
+++ b/BeyondChaos/tables/patch_junction_focus.txt
@@ -1,7 +1,7 @@
 .addr   jun-checker                     610000
 .addr   jun-check-entity-living         610600
 .addr   main-focus                      620800
-.addr   main-lucid-dead                 620870
+.addr   main-lucid-dead                 620860
 .addr   return-focus                    02095c
 .addr   check-lucid-dead                620d00
 .addr   check-focus                     620d80

--- a/BeyondChaos/tables/patch_junction_focus_umaro.txt
+++ b/BeyondChaos/tables/patch_junction_focus_umaro.txt
@@ -1,20 +1,49 @@
 .addr   jun-checker                     610000
-.addr   main-umaro                      620850
+.addr   main-umaro                      621a40
 .addr   return-umaro                    0208c5
 .addr   return-not-umaro                02092a
+.addr   check-able-bodied               620d40
 
 .def    jun-index-focus         08
+.def    jun-index-commander     56
 
 020926: 5c $main-umaro
 
 $main-umaro
+:       48 da
 :       c9 {{berserker-index:0d}}
-:       d0 not-umaro
+:       d0 exit-not-berserk
 :       a9 jun-index-focus
 :       22 $jun-checker
-:       d0 not-umaro
+:       d0 exit-not-berserk
+.label not-focus
+:       a2 06
+.label commander-loop
+:       8a
+:       c3 01
+:       f0 commander-skip
+:       20 $check-able-bodied,2
+:       f0 commander-skip
+:       a9 jun-index-commander
+:       22 $jun-checker
+:       f0 commander-skip
+:       80 exit-not-berserk
+.label commander-skip
+:       ca ca
+:       10 commander-loop
+.label exit-berserk
+:       fa
+:       a9 fd
+:       3d a0 3a
+:       9d a0 3a
+:       68
 :       5c $return-umaro
-.label not-umaro
+.label exit-not-berserk
+:       fa
+:       a9 02
+:       1d a0 3a
+:       9d a0 3a
+:       68
 :       5c $return-not-umaro
 
 VALIDATION

--- a/BeyondChaos/tables/patch_junction_prehit_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_prehit_trigger.txt
@@ -38,6 +38,7 @@
 .def    jun-index-sunken-state      8e
 .def    jun-index-decisive          9c
 .def    jun-index-gaia-assist       a1
+.def    jun-index-flinch            a2
 
 .def    vanish-spell-index          26
 .def    spell-proc-command-index    43
@@ -55,6 +56,13 @@ $main
 :       e2 20
 :       64 fe
 :       da
+
+:       a9 80
+:       1d 04 32
+:       9d 04 32
+:       a9 80
+:       19 04 32
+:       99 04 32
 
 :       b9 0d 3f
 :       f0 no-freeze
@@ -153,6 +161,18 @@ $main-counter
 
 :       22 $jun-check-are-same-team
 :       d0 no-counter-all
+
+:       22 $jun-rng1
+:       90 no-flinch
+:       a9 jun-index-flinch
+:       22 $jun-checker
+:       f0 no-flinch
+:       b9 19 32
+:       4a 4a
+:       f0 no-flinch
+:       99 19 32
+
+.label no-flinch
 :       22 $jun-rng2
 :       29 03
 :       d0 no-counter-all

--- a/BeyondChaos/tables/patch_junction_ravenous.txt
+++ b/BeyondChaos/tables/patch_junction_ravenous.txt
@@ -8,9 +8,17 @@
 020e02: 5c $main
 
 $main
+:       da
+:       8a
+:       38
+:       e9 14 00
+:       30 using_hp
+:       aa
+.label using_hp
 :       a9 jun-index-ravenous 00
 :       22 $jun-checker
 :       f0 exit-normal
+:       fa
 
 :       a5 f0
 :       4a
@@ -28,6 +36,7 @@ $main
 :       5c $return-ravenous
 
 .label exit-normal
+:       fa
 :       b9 f4 3b
 :       c5 f0
 :       5c $return-normal

--- a/BeyondChaos/tables/patch_mp_color_digits.txt
+++ b/BeyondChaos/tables/patch_mp_color_digits.txt
@@ -1,0 +1,150 @@
+# Title: Decoupled Color-Coded MP Digits
+# Author: SilentEnigma (updates), Imzogelmo (original implementation)
+# Version: 1.3
+# Release Date: 2021-04-19
+# Applies to: Final Fantasy III (v1.0) (U)
+
+.addr   main1       57f080
+
+00de5e: 09 01
+:       48
+:       b2 76
+:       c9 0b
+:       f0 05
+:       68
+:       20 a4 de
+:       48 68
+:       9d 1a 63
+:       6b
+
+:       09 01
+:       48
+:       b2 76
+:       c9 03
+:       f0 05
+:       68
+:       20 a4 de
+:       48 68
+:       9d 3f 7b
+:       6b
+
+:       48
+:       bd 1a 63
+:       80 04
+:       48
+:       bd 3f 7b
+:       29 40
+:       f0 06
+:       68 18
+:       69 04
+:       80 01
+:       68
+:       99 03 03
+:       99 07 03
+:       6b
+
+:       63 14
+:       ae 7e
+
+:       48 da
+:       7b
+:       aa
+:       bf a0 de c0
+:       9d f8 7f
+:       9d f8 7d
+:       e8
+:       e0 04 00
+:       d0 f0
+:       fa 68
+:       09 40
+:       60
+
+012b9b: ea ea
+:       22 8a de c0
+
+012d2b: ea ea
+:       22 84 de c0
+
+0191a0: b3 a4
+
+0191a6: 09 96
+
+01a5a9: ea
+:       22 5e de c0
+
+01a6e6: ea
+:       22 71 de c0
+
+01ac21: 90 07
+:       22 @main3,3
+:       20 5b ac
+:       20 35 ac
+:       60
+
+01ac2e: 20 b3 9c
+:       6b
+:       ff ff ff
+
+0263a8: 22 $main1
+
+0263b9: 5c @main2,3
+:       ea
+
+$main1
+:       eb
+:       48
+:       e2 20
+:       ad a3 11
+:       c2 20
+:       10 05
+:       68
+:       09 05 00
+:       6b
+:       68
+:       09 0b 00
+:       6b
+
+.label main2
+:       a9 03
+:       48
+:       ad a3 11
+:       10 05
+:       68
+:       a9 08
+:       80 01
+:       68
+:       f4 bd 63
+:       5c 9b 62 c2
+
+.label main3
+:       7b
+:       a8
+:       84 1e
+:       c8 c8
+:       b1 76
+:       22 2e ac c1
+:       da
+:       7b
+:       aa
+:       bf a1 c6 c2
+:       9d f8 7f
+:       9d f8 7d
+:       e8
+:       e0 08 00
+:       d0 f0
+:       fa
+:       6b
+
+VALIDATION
+
+00de5e: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+012b9b: 99 03 03 99 07 03
+012d2b: 99 03 03 99 07 03
+0191a0: e2 93
+0191a6: e2 93
+01a5a9: 09 01 9d 1a 63
+01a6e6: 09 01 9d 3f 7b
+01ac22: 0e 7b a8 84 1e c8 c8 b1 76 20 b3 9c
+01ac2f: 5b ac 20 35 ac 60
+0263a9: 09 0b 00
+0263bc: 9b 62

--- a/BeyondChaos/tables/tags_equip.json
+++ b/BeyondChaos/tables/tags_equip.json
@@ -1,6 +1,5 @@
 {
     "Dirk": [
-        "physical"
     ],
     "MithrilKnife": [
         "physical"
@@ -732,5 +731,7 @@
     ],
     "Sprint Shoes": [
         "haste"
+    ],
+    "Rename Card": [
     ]
 }

--- a/BeyondChaos/utils.py
+++ b/BeyondChaos/utils.py
@@ -78,8 +78,6 @@ MODIFIERS_TABLE = path.join(custom_path, "moves.txt")
 MOVES_TABLE = path.join(custom_path, "moves.txt")
 CORAL_TABLE = path.join(custom_path, "coralnames.txt")
 
-MYSELF_BLOB = path.join(tblpath, 'myself_blob.bin')
-
 parent_connection = None
 
 

--- a/README.md
+++ b/README.md
@@ -248,34 +248,35 @@ A: The best way to report it is on the Beyond Chaos Discord in the #bugs channel
 ## CONTRIBUTORS
 
     Abyssonym - original Beyond Chaos creator
-    subtractionsoup - former maintainer of Beyond Chaos EX 
+    subtractionsoup - former maintainer of Beyond Chaos EX
     CtrlxZ - created or modified a bunch of sprites for the randomizer
-	HoxNorf - ported over sprites and music for the randomizer
+    HoxNorf - ported over sprites and music for the randomizer
     DarkSlash - madworld, darkworld, randombosses codes and some other things for KatN mode; current maintainer of Beyond Chaos CE (send help)
     emberling - speeddial, randomized music, alasdraco, dialoguemanager, converted a ton of music, and reworked palettes and sprite replacement, FF6 music player patch
-	Rushlight - made music arrangements for the randomizer
+    Rushlight - made music arrangements for the randomizer
     Lockirby2 - The worringtriad and notawaiter codes
     myself086 - new menu features and natural magic expansion
     Dracovious - Created new GUI and R-Limit, and some other codes
-	GreenKnight5 - First GUI, Cecilbot
-	DrInsanoPHD - Refactoring code, character stats randomizer, bug fixes, lots of help with CE releases
-	Crimdahl - Rotating status patch, dancelessons code, removeflashing code, lots of help with CE releases, 
-	fusoyeahhh - lots of help with CE releases
-	RazzleStorm - refactoring some code, adding type hints, lots of help with CE releases
-	CDude - lots of help with event codes for CE versions, fixing Bio Blast and Flash/Schiller animations
-	Cecil188 - ported over music, owner of the Discord, and overall helper with everything
-	
+    GreenKnight5 - First GUI, Cecilbot
+    DrInsanoPHD - Refactoring code, character stats randomizer, bug fixes, lots of help with CE releases
+    Crimdahl - Rotating status patch, dancelessons code, removeflashing code, lots of help with CE releases,
+    fusoyeahhh - lots of help with CE releases
+    RazzleStorm - refactoring some code, adding type hints, lots of help with CE releases
+    CDude - lots of help with event codes for CE versions, fixing Bio Blast and Flash/Schiller animations
+    Cecil188 - ported over music, owner of the Discord, and overall helper with everything
+
 
 ## EXTERNAL PATCHES USED
 
-	Synchysi - esper restriction
-	Lenophis - unhardcoded tintinabar
+    Synchysi - esper restriction
+    Lenophis - unhardcoded tintinabar
     Novalia Spirit - "Allergic Dog" bug fix, Selective Reequip
     Leet Sketcher - Y Equip Relics, rotating statuses patch, Imp Skimp
     Assassin - That Damn Yellow Streak fix, sketch fix
-	Power Panda - Divergent Paths: The 3 Scenarios
-	HatZen08 - Coliseum Rewards Display
-	madsiur, tsushiy, Lenophis - FF6 Music Player
+    Power Panda - Divergent Paths: The 3 Scenarios
+    HatZen08 - Coliseum Rewards Display
+    madsiur, tsushiy, Lenophis - FF6 Music Player
+    SilentEnigma, Imzogelmo - MP damage color digits
 
 ## SPECIAL THANKS
 


### PR DESCRIPTION
This pull request syncs the Junction patch set with BCG v7.3:

- Added two new junction effects.
- Spell availability lists are updated after every combat action (for junctions such as Blood Mage)
- Fixed bug where monsters with Final Summon would cast fire instead of nothing.
- The Commander junction now works on Umaro.
- Ravenous now works on MP draining.

Additionally, I've included the MP damage color patch, since several junction effects can cause MP damage or healing, which can be confusing with using different colors to indicate damage type.