### PR TITLE
Fix Description Disruption conflict, Informative Miss counter bug

### DIFF
--- a/BeyondChaos/monsterrandomizer.py
+++ b/BeyondChaos/monsterrandomizer.py
@@ -86,6 +86,7 @@ solo_bosses = [
     259,  # vargas
     334,  # leader
     260,  # tunnel armor
+    371,  # thamasa kefka
 ]
 
 elemlist = ["fire", "ice", "bolt", "bio", "wind", "pearl", "earth", "water"]

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -12,7 +12,7 @@ from multiprocessing import Pipe, Process
 import character
 import locationrandomizer
 import options
-from monsterrandomizer import MonsterBlock, early_bosses
+from monsterrandomizer import MonsterBlock, early_bosses, solo_bosses
 from randomizers.characterstats import CharacterStats
 from ancient import manage_ancient
 from appearance import manage_character_appearance, manage_coral
@@ -5040,12 +5040,13 @@ def junction_everything(jm: JunctionManager, outfile_rom_buffer: BytesIO):
                     outfile_rom_buffer.seek(equip_address)
                     outfile_rom_buffer.write(bytes([new_equip]))
 
+    banned_bosses = set(early_bosses + solo_bosses)
     if Options_.is_flag_active('effectster'):
         monsters = get_monsters()
         jm.reseed('premonster')
         valid_monsters = []
         for m in monsters:
-            if m.id in early_bosses:
+            if m.id in banned_bosses:
                 continue
             if m.id not in jm.monster_tags:
                 continue
@@ -5061,7 +5062,7 @@ def junction_everything(jm: JunctionManager, outfile_rom_buffer: BytesIO):
     if Options_.is_flag_active('treaffect'):
         monsters = get_monsters()
         for m in monsters:
-            if m.id not in early_bosses:
+            if m.id not in banned_bosses:
                 continue
             for item in m.steals + m.drops:
                 if item is None:

--- a/BeyondChaos/tables/patch_alphabetized_lores.txt
+++ b/BeyondChaos/tables/patch_alphabetized_lores.txt
@@ -11,7 +11,7 @@
 #.addr   main-c3f        03ff4c
 
 .addr   main-c26        0267f0
-.addr   main-c3f        03ff4c
+.addr   main-c3f        03ff50
 .addr   lore-order      57f800
 
 025564: e8

--- a/BeyondChaos/tables/patch_description_disruption.txt
+++ b/BeyondChaos/tables/patch_description_disruption.txt
@@ -4,15 +4,42 @@
 # Release Date: 2021-03-01
 # Applies to: FF3us 1.0, FF3us 1.1
 # Tested on: Final Fantasy III (v1.0) (U)
+# c3/0f25 and set $45:10 to allow drawing in myself's menu?
 
-0302a3: 30 ff                                               # 0302a5
-03a897: 20 3b ff                                            # 03a89a
-03ff30: a9 10 14 45  20 fd 0e 18  4c 83 89 48  a5 26 c9 5e
-:       f0 08 4a c9  32 f0 03 9e  49 36 68 60               # 03ff4c
+.addr   main1       03ff20
+
+0302a3: $main1,2                                            # 0302a5
+03899f: 20 @main3,2
+:       ea
+03a897: 20 @main2,2                                         # 03a89a
+
+$main1
+:       a9 10
+:       14 45
+:       20 fd 0e
+:       18
+:       4c 83 89
+
+.label main2
+:       48 a5 26 c9 5e f0 08 4a c9 32 f0 03 9e 49 36 68 60
+
+# allow equipment sub-sub-menu (Myself's feature) to redraw
+.label main3
+:       a9 5e
+:       85 27
+:       a9 10
+:       04 45
+:       20 25 0f
+:       20 89 0f
+:       60
+
 
 VALIDATION
 
 0302a3: 83 89                                               # 0302a5
+03899f: a9 5e
+:       85 27
 03a897: 9e 49 36                                            # 03a89a
-03ff30: ff ff ff ff  ff ff ff ff  ff ff ff ff  ff ff ff ff
-:       ff ff ff ff  ff ff ff ff  ff ff ff ff               # 03ff4c
+03ff20: ff ff ff ff  ff ff ff ff  ff ff ff ff  ff ff ff ff
+:       ff ff ff ff  ff ff ff ff  ff ff ff ff  ff ff ff ff
+:       ff ff ff ff  ff ff ff ff  ff ff ff ff  ff ff ff ff  # 03ff50

--- a/BeyondChaos/tables/patch_informative_miss.txt
+++ b/BeyondChaos/tables/patch_informative_miss.txt
@@ -27,17 +27,17 @@
 :       03 20 44 67  ad a7 11 4a  90 03 ee 48               # 02447c
 026348: 20 66 67 90  06 09                                  # 02634e
 02636f: a4 f0                                               # 026371
-026395: 4c 88 67                                            # 026398
+026395: 4c 8b 67                                            # 026398
 026700: 9c 5a 3a 9c  56 3f 9c 54  3f 60 a5 fc  05 f4 85 e8
 :       39 1c 33 60  c2 20 20 ff  44 ad aa 11  85 ea ad ac
 :       11 85 ec 9c  aa 11 9c ac  11 60 20 06  44 a5 ea 8d
 :       aa 11 a5 ec  8d ac 11 60  b9 a1 3a 80  03 b9 80 3c
 :       89 04 f0 0a  08 c2 20 b9  18 30 0c 54  3f 28 60 99
 :       e8 3d 80 07  b9 40 3b c5  ee 90 0a 08  c2 20 b9 18
-:       30 0c 56 3f  28 60 18 a2  04 3c 52 3f  d0 04 ca ca
-:       d0 f7 1c 5a  3a d0 07 ca  30 03 0c 5a  3a 60 1c 56
-:       3f 1c 54 3f  38 8a eb 60  ad 5a 3a f0  05 64 f2 4c
-:       f5 62 7a fa  60                                     # 026795
+:       30 0c 56 3f  28 60 da 18  a2 04 3c 52  3f d0 04 ca
+:       ca d0 f7 1c  5a 3a d0 08  ca 30 03 0c  5a 3a fa 60
+:       1c 56 3f 1c  54 3f 38 8a  eb fa 60 ad  5a 3a f0 05
+:       64 f2 4c f5  62 7a fa 60                            # 026798
 12e000: 8c                                                  # 12e001
 12e009: e0                                                  # 12e00a
 12e014: 03 b8                                               # 12e016
@@ -253,7 +253,7 @@ VALIDATION
 :       ff ff ff ff  ff ff ff ff  ff ff ff ff  ff ff ff ff
 :       ff ff ff ff  ff ff ff ff  ff ff ff ff  ff ff ff ff
 :       ff ff ff ff  ff ff ff ff  ff ff ff ff  ff ff ff ff
-:       ff ff ff ff  ff                                     # 026795
+:       ff ff ff ff  ff ff ff ff                            # 026798
 12e000: 44                                                  # 12e001
 12e009: dd                                                  # 12e00a
 12e014: ca bf                                               # 12e016

--- a/BeyondChaos/tables/patch_junction_caller.txt
+++ b/BeyondChaos/tables/patch_junction_caller.txt
@@ -182,9 +182,9 @@ $check-esper-owned
 :       48
 :       a3 02
 :       29 07
+:       e2 10
 :       aa
 :       bf $bits
-:       e2 10
 :       fa
 :       3c 69 1a
 :       d0 esper-is-owned


### PR DESCRIPTION
The new Description Disruption patch breaks the scrolling to see equipment effects in Myself's menu patch. This fixes it so that both patches are functional.