### PR TITLE
Junctions critical fixes & more

### DIFF
--- a/BeyondChaos/bcg_junction.py
+++ b/BeyondChaos/bcg_junction.py
@@ -140,8 +140,17 @@ class JunctionManager:
                 full_data[key] = value
 
             if isinstance(value, dict):
-                if key not in ('junction_indexes', 'patch_parameters'):
+                if key not in ('junction_indexes', 'patch_parameters',
+                               'global_addresses'):
                     assert all(isinstance(k, int) for k in value.keys())
+
+            if key.endswith('_address'):
+                value = full_data[key]
+                global_key = key[:-len('_address')].replace('_', '-')
+                if global_key in full_data['global_addresses']:
+                    assert full_data['global_addresses'][global_key] == value
+                else:
+                    full_data['global_addresses'][global_key] = value
 
             if key.endswith('_address') or key.startswith('num_'):
                 full_data[key] = self.clean_number(full_data[key])
@@ -168,6 +177,21 @@ class JunctionManager:
                 tags = {self.get_category_index(category, k): v
                         for (k, v) in tags.items()}
                 setattr(self, key, tags)
+
+        for k, v in sorted(self.junction_indexes.items()):
+            k = k.replace('_', '-')
+            k = 'jun-index-%s' % k
+            if k in self.patch_parameters:
+                assert self.patch_parameters[k] == v
+            else:
+                self.patch_parameters[k] = v
+
+        for k, v in sorted(self.global_addresses.items()):
+            k = 'jun-global-%s' % k
+            if k in self.patch_parameters:
+                assert self.patch_parameters[k] == v
+            else:
+                self.patch_parameters[k] = v
 
     @property
     def report(self):

--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -730,33 +730,39 @@ NORMAL_FLAGS = [
     Flag(name='espffect',
          description='ESPER JUNCTION EFFECTS MODE',
          long_description='Attach random effects from the "Junction" patch '
-                          'set to espers. Low potential for softlocks.',
+                          'set to espers.',
          category='experimental',
          inputtype='boolean'),
     Flag(name='effectmas',
          description='EQUIPMENT JUNCTION EFFECTS MODE',
          long_description='Attach random effects from the "Junction" patch '
-                          'set to equipment (excluding relics). Medium '
+                          'set to equipment (excluding relics). Low '
                           'potential for softlocks.',
          category='experimental',
          inputtype='boolean'),
     Flag(name='effectory',
          description='RELIC JUNCTION EFFECTS MODE',
          long_description='Attach random effects from the "Junction" patch '
-                          'set to relics. Medium potential for softlocks.',
+                          'set to relics. Low potential for softlocks.',
          category='experimental',
          inputtype='boolean'),
     Flag(name='effectster',
          description='MONSTER JUNCTION EFFECTS MODE',
          long_description='Attach random effects from the "Junction" patch '
-                          'set to monsters, rages, and some statuses. High '
+                          'set to monsters, rages, and some statuses. Medium '
                           'potential for softlocks.',
          category='experimental',
          inputtype='boolean'),
     Flag(name='treaffect',
          description='MONSTER EQUIPMENT JUNCTION EFFECTS MODE',
          long_description='Monsters inherit the "Junction" effects of held '
-                          'items. High potential for softlocks.',
+                          'items. Medium potential for softlocks.',
+         category='experimental',
+         inputtype='boolean'),
+    Flag(name='jejentojori',
+         description='MEMENTO MORI JUNCTIONS MODE',
+         long_description='Innate "mementomori" relics retain their junction '
+                          'effects. High potential for softlocks.',
          category='experimental',
          inputtype='boolean'),
 

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -5074,6 +5074,17 @@ def junction_everything(jm: JunctionManager, outfile_rom_buffer: BytesIO):
         JUNCTION_MANAGER_PARAMETERS['monster-equip-steal-enabled'] = 1
         JUNCTION_MANAGER_PARAMETERS['monster-equip-drop-enabled'] = 1
 
+    if Options_.is_flag_active("jejentojori"):
+        for c in get_characters():
+            if c.id >= 0x10:
+                continue
+            if not hasattr(c, 'relic_selection'):
+                continue
+            junctions = jm.equip_whitelist[c.relic_selection]
+            for j in junctions:
+                jm.add_junction(c.id, j, 'whitelist',
+                                force_category='character')
+
     if jm.activated:
         jm.match_esper_monster_junctions()
 

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -5029,10 +5029,10 @@ def junction_everything(jm: JunctionManager, outfile_rom_buffer: BytesIO):
                 if junctions:
                     if equipid in pool:
                         old_rank = pool.index(equipid) / (len(pool)-1)
-                    else:
-                        assert equiptype == 'weapon'
-                        assert equipid in shields
+                    elif equiptype == 'weapon' and equipid in shields:
                         old_rank = shields.index(equipid) / (len(shields)-1)
+                    else:
+                        old_rank = random.random()
                     index = int(round(old_rank * (len(fallback)-1)))
                     new_equip = fallback[index]
                     old_item = [i for i in items if i.itemid == equipid][0]

--- a/BeyondChaos/tables/bcg_junction_manifest.json
+++ b/BeyondChaos/tables/bcg_junction_manifest.json
@@ -25,7 +25,7 @@
 
     "junction_indexes": {
         "esper_magic":          "01",
-        "perfect_taunt":        "02",
+        "junction_jammer":      "02",
         "taunt":                "03",
         "initiative":           "04",
         "instant_run":          "05",
@@ -78,7 +78,7 @@
         "leech":                "36",
         "sneeze_guard":         "37",
         "critical_morph":       "38",
-        "critical_revenge":     "39",
+        "meatbone_cut":         "39",
         "critical_escape":      "3a",
         "boost_crit":           "3b",
         "loner":                "3c",
@@ -187,12 +187,17 @@
         "double_time":          "a3",
         "plague":               "a4",
         "discordant":           "a5",
-        "null_sleep":           "a6"
+        "null_sleep":           "a6",
+        "luck_font":            "a7",
+        "luck_sink":            "a8",
+        "juggernaut":           "a9",
+        "burst":                "aa",
+        "life_force":           "ab"
     },
 
     "junction_short_names": {
         "esper_magic":          "EspMag-J",
-        "perfect_taunt":        "Perf. Taunt",
+        "junction_jammer":      "Junction Jam",
         "taunt":                "Taunt",
         "initiative":           "First Strike",
         "instant_run":          "Instant Run",
@@ -246,7 +251,7 @@
         "critical_gprain":      "SOS GP Rain",
         "critical_esper":       "SOS Summon",
         "critical_jump":        "SOS Jump",
-        "critical_revenge":     "Meatbone Cut",
+        "meatbone_cut":         "Meatbone Cut",
         "boost_crit":           "Crit Boost",
         "loner":                "Loner",
         "crisis_arm":           "Crisis Arm",
@@ -354,12 +359,17 @@
         "double_time":          "Double Time",
         "plague":               "Plague",
         "discordant":           "Discordant",
-        "null_sleep":           "Null Sleep?"
+        "null_sleep":           "Null Sleep?",
+        "luck_font":            "Luck Font",
+        "luck_sink":            "Luck Sink",
+        "juggernaut":           "Juggernaut",
+        "burst":                "Burst",
+        "life_force":           "Life Force"
     },
 
     "junction_tags": {
         "esper_magic":          ["esper", "magic"],
-        "perfect_taunt":        ["defend"],
+        "junction_jammer":      ["luck", "defend", "debuff", "-status"],
         "taunt":                ["defend"],
         "initiative":           ["haste"],
         "instant_run":          ["hide", "haste"],
@@ -412,7 +422,7 @@
         "leech":                ["drain", "status", "debuff", "poison", "seizure", "regen"],
         "sneeze_guard":         ["hide"],
         "critical_morph":       ["buff"],
-        "critical_revenge":     ["death"],
+        "meatbone_cut":         ["death"],
         "critical_escape":      ["hide"],
         "boost_crit":           ["luck"],
         "loner":                ["death"],
@@ -521,7 +531,12 @@
         "double_time":          ["haste", "buff"],
         "plague":               ["condemned", "death", "status", "debuff", "haste", "slow"],
         "discordant":           ["luck", "buff", "debuff"],
-        "null_sleep":           ["status", "sleep"]
+        "null_sleep":           ["status", "sleep"],
+        "luck_font":            ["luck"],
+        "luck_sink":            ["-luck"],
+        "juggernaut":           ["buff", "slow"],
+        "burst":                ["buff", "haste"],
+        "life_force":           ["life", "-death", "heal"]
     },
 
     "esper_tags":       "tags_esper.json",
@@ -743,24 +758,89 @@
     "monster_blacklist":    {
         "Kefka 11a":        ["astral"],
         "Kefka 12a":        ["astral"],
-        "every_monster":    ["taunt", "quickening", "reverse"]
+        "every_monster":    ["quickening", "reverse"]
     },
 
     "always_banlist":       [],
     "character_banlist":    [],
-    "esper_banlist":        ["perfect_taunt", "repel_nuke", "caller"],
-    "equip_banlist":        ["perfect_taunt", "repel_nuke", "boost_nuke"],
+    "esper_banlist":        ["repel_nuke", "caller"],
+    "equip_banlist":        ["repel_nuke", "boost_nuke"],
     "status_banlist":       [],
     "monster_banlist":      [
-        "taunt", "esper_magic", "esper_defense", "esper_counter",
-        "esper_attack", "reverse", "astral", "quickening", "vip"],
+        "esper_magic", "esper_defense", "esper_counter", "esper_attack",
+        "reverse", "astral", "quickening", "vip"],
 
     "patch_parameters": {
-        "morpher-index":                    "00",
-        "berserker-index":                  "0d",
-        "monster-equip-steal-enabled":      "01",
-        "monster-equip-drop-enabled":       "01",
-        "every_monster_index":              "180"
+        "morpher-index":                        "00",
+        "berserker-index":                      "0d",
+        "monster-equip-steal-enabled":          "01",
+        "monster-equip-drop-enabled":           "01",
+        "every-monster-index":                  "180",
+        "jun-command-index-summon":             "40",
+        "jun-command-index-jump":               "41",
+        "jun-command-index-custom-mp-spell":    "42",
+        "jun-command-index-spell-proc":         "43",
+        "jun-command-index-final-attack":       "44",
+        "jun-command-index-fixed-damage":       "45",
+        "jun-data-bank":                        "61"
+    },
+
+    "global_addresses": {
+        "bit-to-combatant-index":           "6109c0",
+        "bit-to-index":                     "6108d0",
+        "check-are-same-team":              "6105e0",
+        "check-blacklist":                  "610180",
+        "check-blacklist-monster-version":  "6102c0",
+        "check-count-all-living":           "610680",
+        "check-entity-can-act":             "6106c0",
+        "check-entity-living":              "610600",
+        "check-entity-present":             "610640",
+        "check-equip-blacklist":            "610210",
+        "check-equip-whitelist":            "610200",
+        "check-inventory":                  "610700",
+        "check-is-damage-over-time":        "610920",
+        "check-list":                       "6101e0",
+        "check-monster-equip-blacklist":    "610480",
+        "check-monster-equip-whitelist":    "610400",
+        "check-rage":                       "610300",
+        "check-spell-targets-ally":         "610960",
+        "check-status-blacklist":           "6103a0",
+        "check-status-whitelist":           "610340",
+        "check-whitelist":                  "610100",
+        "check-whitelist-monster-version":  "610280",
+        "checker":                          "610000",
+        "checker-y":                        "6100e0",
+        "command-custom-mp-spell":          "61f184",
+        "command-final-attack":             "61f188",
+        "command-fixed-damage":             "61f18a",
+        "command-jump":                     "61f182",
+        "command-spell-proc":               "61f186",
+        "command-summon":                   "61f180",
+        "command-table-address":            "61f100",
+        "compare-x-y":                      "6109a0",
+        "count-bits":                       "6108c0",
+        "deduct-item-if-possible":          "610740",
+        "dispatcher-return":                "610fff",
+        "divide":                           "610860",
+        "force-update":                     "610fe0",
+        "free-status-bytes-main":           "617fc0",
+        "generic-dispatch":                 "610f00",
+        "get-command-subroutine":           "61f000",
+        "get-command-jump":                 "61f020",
+        "get-equipped-esper":               "610900",
+        "monster-equip-steal-enabled":      "6104fc",
+        "monster-equip-drop-enabled":       "6104fe",
+        "mult":                             "610800",
+        "queue-command":                    "610ff0",
+        "queue-self-spell":                 "610fc0",
+        "reload-character-commands":        "610f80",
+        "rng1":                             "610a00",
+        "rng2":                             "610a40",
+        "rng2-noluck":                      "610aa0",
+        "rng3":                             "610a20",
+        "select-bit":                       "6108a0",
+        "set-target-allies":                "610780",
+        "set-target-counter":               "6107c0"
     },
 
     "core_patch_list": [
@@ -776,8 +856,8 @@
         "esper_magic": [
             "patch_junction_esper_magic_proc.txt"
         ],
-        "perfect_taunt": [
-            "patch_junction_taunt_salve.txt"
+        "junction_jammer": [
+            "patch_junction_core.txt"
         ],
         "taunt": [
             "patch_junction_taunt_salve.txt"
@@ -945,8 +1025,8 @@
             "patch_junction_critical_trigger.txt",
             "patch_junction_command_jump.txt"
         ],
-        "critical_revenge": [
-            "patch_junction_critical_trigger.txt"
+        "meatbone_cut": [
+            "patch_junction_damage_trigger.txt"
         ],
         "boost_crit": [
             "patch_junction_boost_crit.txt"
@@ -1136,7 +1216,8 @@
         ],
         "mp_switch": [
             "patch_junction_mp_switch.txt",
-            "patch_junction_prehit_trigger.txt"
+            "patch_junction_prehit_trigger.txt",
+            "patch_junction_command_fixed_damage.txt"
         ],
         "mp_regen": [
             "patch_junction_mp_regen.txt",
@@ -1218,7 +1299,8 @@
         ],
         "quickening": [
             "patch_junction_hit_trigger.txt",
-            "patch_junction_command_custom_mp_spell.txt"
+            "patch_junction_command_custom_mp_spell.txt",
+            "patch_junction_command_fixed_damage.txt"
         ],
         "gunblade": [
             "patch_junction_hit_trigger.txt"
@@ -1281,6 +1363,25 @@
         ],
         "null_sleep": [
             "patch_junction_prehit_trigger.txt"
+        ],
+        "luck_font": [
+            "patch_junction_core.txt",
+            "patch_junction_luck_font_sink.txt"
+        ],
+        "luck_sink": [
+            "patch_junction_core.txt",
+            "patch_junction_luck_font_sink.txt"
+        ],
+        "juggernaut": [
+            "patch_junction_miasma.txt",
+            "patch_junction_initiative.txt"
+        ],
+        "burst": [
+            "patch_junction_miasma.txt",
+            "patch_junction_initiative.txt"
+        ],
+        "life_force": [
+            "patch_junction_damage_modification.txt"
         ]
     }
 }

--- a/BeyondChaos/tables/patch_alphabetized_lores.txt
+++ b/BeyondChaos/tables/patch_alphabetized_lores.txt
@@ -11,7 +11,7 @@
 #.addr   main-c3f        03ff4c
 
 .addr   main-c26        0267f0
-.addr   main-c3f        03ff50
+.addr   main-c3f        03fec0
 .addr   lore-order      57f800
 
 025564: e8
@@ -33,12 +33,24 @@ $main-c26
 0352a0: 68 ea                                               # 0352a2
 
 $main-c3f
-:       a2 89 9d 8e  81 21 a6 00
+:       7b
+:       a2 89 9d
+:       8e 81 21
+:       a6 00
 :       bf $lore-order
 :       a8 da 18
 :       22 @main-c2f,3
-:       3c 29 1d f0  03 98 80 02  a9 ff 8d 80  21 fa e8 e0
-:       18 00 d0 e1  60
+:       3c 29 1d
+:       f0 03
+:       98
+:       80 02
+:       a9 ff
+:       8d 80 21
+:       fa
+:       e8
+:       e0 18 00
+:       d0 e1
+:       60
 
 $lore-order
 :       04 03 06 05  02 00 10 17  0f 16 0b 0a  09 0d 08 12

--- a/BeyondChaos/tables/patch_junction_art_license.txt
+++ b/BeyondChaos/tables/patch_junction_art_license.txt
@@ -1,12 +1,10 @@
-.addr   jun-checker                 610000
+.addr   jun-checker                 {{jun-global-checker}}
 .addr   main-level                  622600
 .addr   main-sketch-rate            622680
 .addr   main-sketch-ailments        6226c0
 
 .addr   sketch-rate-return-normal   023b3d
 .addr   sketch-rate-return-success  023b42
-
-.def    jun-index           96
 
 022c22: 22 $main-level
 :       fa 60
@@ -24,7 +22,7 @@ $main-level
 
 :       9b
 :       aa
-:       a9 jun-index
+:       a9 {{jun-index-art-license}}
 :       22 $jun-checker
 :       f0 exit-normal
 
@@ -67,7 +65,7 @@ $main-level
 :       6b
 
 $main-sketch-rate
-:       a9 jun-index
+:       a9 {{jun-index-art-license}}
 :       22 $jun-checker
 :       d0 exit-sketch-rate-success
 :       bd 45 3c
@@ -84,7 +82,7 @@ $main-sketch-ailments
 :       30 ailments-not-sketching
 :       aa
 
-:       a9 jun-index
+:       a9 {{jun-index-art-license}}
 :       22 $jun-checker
 :       f0 ailments-not-sketching
 

--- a/BeyondChaos/tables/patch_junction_barehanded.txt
+++ b/BeyondChaos/tables/patch_junction_barehanded.txt
@@ -1,9 +1,7 @@
-.addr   jun-checker                     610000
-.addr   jun-mult                        610800
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-mult                        {{jun-global-mult}}
 
 .addr   main                            621b80
-
-.def    jun-index       9b
 
 0228ea: 22 $main
 :       ea
@@ -11,7 +9,7 @@
 $main
 :       da 08
 :       c2 30
-:       a9 jun-index 00
+:       a9 {{jun-index-barehanded}} 00
 :       22 $jun-checker
 :       f0 holding-equipment
 :       bd 10 30

--- a/BeyondChaos/tables/patch_junction_boost_crit.txt
+++ b/BeyondChaos/tables/patch_junction_boost_crit.txt
@@ -1,14 +1,12 @@
-.addr   jun-checker                 610000
+.addr   jun-checker                 {{jun-global-checker}}
 .addr   main                        6203c0
-
-.def    jun-index           3b
 
 02340c: 22 $main
 
 $main
 :       e6 bc
 :       e6 bc
-:       a9 jun-index
+:       a9 {{jun-index-boost-crit}}
 :       22 $jun-checker
 :       f0 no-junction
 :       c2 20

--- a/BeyondChaos/tables/patch_junction_caller.txt
+++ b/BeyondChaos/tables/patch_junction_caller.txt
@@ -1,5 +1,5 @@
-.addr   jun-checker                     610000
-.addr   jun-mult                        610800
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-mult                        {{jun-global-mult}}
 
 .addr   main-multicast                  6217e0
 .addr   main                            621800
@@ -14,9 +14,10 @@
 .addr               check-can-equip-esper           621a00
 .addr                   esper-allocations-address       {{esper-allocations-address}}
 .addr           set-new-esper                   621960
-.addr               get-mp-cost-targeting           6219a0
-.addr                   mp-costs-address                046db4
-.addr                   targetings-address              046db9
+.addr               get-mp-cost-targeting           621c40
+.addr                   targetings-address              046db4
+.addr                   mp-costs-address                046db9
+.addr                   relic-effects-address           7e3c45
 .addr               check-esper-castable            6219c0
 
 .addr   no-select-disabled-esper        62f200
@@ -32,7 +33,6 @@
 .addr   bits                            00bafc
 .addr   wide-bits                       00b4f3
 
-.def    jun-index           99
 .def    esper-order-list    0e 0d 07 13 0f 18 16 01 11 06 0b 09 14 1a 10 0c 00 02 05 03 15 19 08 04 0a 17 12 ff
 .def    overflow-index      1c
 
@@ -52,7 +52,7 @@ $esper-order-address: esper-order-list
 
 $main-multicast
 :       48
-:       a9 jun-index
+:       a9 {{jun-index-caller}}
 :       22 $jun-checker
 :       d0 allow-multicast
 :       68
@@ -77,7 +77,7 @@ $main
 :       29 03
 :       0a
 :       aa
-:       a9 jun-index
+:       a9 {{jun-index-caller}}
 :       22 $jun-checker
 :       f0 normal-confirm
 
@@ -242,7 +242,7 @@ $set-new-esper
 :       9d 90 20
 :       80 set-new-check-castable
 .label set-new-is-empty
-:       a9 00
+:       a9 ff
 :       9d 91 20
 :       a9 ff
 :       9d 90 20
@@ -258,9 +258,35 @@ $get-mp-cost-targeting
 :       a9 0e
 :       22 $jun-mult
 :       aa
-:       bf $mp-costs-address
-:       eb
 :       bf $targetings-address
+:       eb
+:       bf $mp-costs-address
+
+# gold hairpin/economizer case
+:       48
+:       ad $menu-active-character,2
+:       29 03
+:       0a
+:       e2 10
+:       aa
+:       c2 10
+:       bd $relic-effects-address,2
+:       89 40
+:       f0 no-economizer
+:       68
+:       a9 01
+:       80 finish-hairpin-economizer
+.label no-economizer
+:       89 20
+:       f0 no-gold-hairpin
+:       68
+:       1a
+:       4a
+:       80 finish-hairpin-economizer
+.label no-gold-hairpin
+:       68
+.label finish-hairpin-economizer
+
 :       fa
 :       60
 

--- a/BeyondChaos/tables/patch_junction_command_custom_mp_spell.txt
+++ b/BeyondChaos/tables/patch_junction_command_custom_mp_spell.txt
@@ -2,11 +2,9 @@
 .addr   reentry-address                 02175f
 .addr   reentry-fail-address            0200e3
 
-.addr   pointer-address                 61f184
+.addr   pointer-address                 {{jun-global-command-custom-mp-spell}}
 
 .addr   living-characters               7e3a74
-
-.def    command-index               42
 
 $main
 :       c2 20

--- a/BeyondChaos/tables/patch_junction_command_expansion.txt
+++ b/BeyondChaos/tables/patch_junction_command_expansion.txt
@@ -1,8 +1,8 @@
-.addr   get-command-subroutine          61f000
-.addr   get-command-jump                61f020
+.addr   get-command-subroutine          {{jun-global-get-command-subroutine}}
+.addr   get-command-jump                {{jun-global-get-command-jump}}
 
-# should reserve 0x200 bytes for the table, up to 61f300
-.addr   jun-command-table-address       61f100
+# should reserve 0x200 bytes for the table, i.e. 61f100-61f300
+.addr   jun-command-table-address       {{jun-global-command-table-address}}
 # c21401 minus one
 .addr   return-addr                     021400
 

--- a/BeyondChaos/tables/patch_junction_command_final_attack.txt
+++ b/BeyondChaos/tables/patch_junction_command_final_attack.txt
@@ -1,8 +1,7 @@
 .addr   main                            628100
 .addr   reentry-address                 02175f
 
-.addr   pointer-address                 61f188
-.def    command-index               44
+.addr   pointer-address                 {{jun-global-command-final-attack}}
 
 $main
 :       a9 02

--- a/BeyondChaos/tables/patch_junction_command_jump.txt
+++ b/BeyondChaos/tables/patch_junction_command_jump.txt
@@ -1,9 +1,8 @@
-.addr   jun-set-target-counter          6107c0
+.addr   jun-set-target-counter          {{jun-global-set-target-counter}}
 .addr   main                            628040
 .addr   reentry-address                 024ecb
 
-.addr   pointer-address                 61f182
-.def    command-index       41
+.addr   pointer-address                 {{jun-global-command-jump}}
 
 $main
 :       bb

--- a/BeyondChaos/tables/patch_junction_command_spell_proc.txt
+++ b/BeyondChaos/tables/patch_junction_command_spell_proc.txt
@@ -1,4 +1,4 @@
-.addr   jun-generic-dispatch                610f00
+.addr   jun-generic-dispatch                {{jun-global-generic-dispatch}}
 
 .addr   main                                628120
 .addr   reentry-address                     02317b
@@ -8,8 +8,7 @@
 
 .addr   living-characters                   7e3a74
 
-.addr   pointer-address                     61f186
-.def    command-index               43
+.addr   pointer-address                     {{jun-global-command-spell-proc}}
 
 $main
 :       bb

--- a/BeyondChaos/tables/patch_junction_command_summon.txt
+++ b/BeyondChaos/tables/patch_junction_command_summon.txt
@@ -1,16 +1,21 @@
-.addr   jun-check-entity-living         610600
-.addr   main                            628000
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-rng3                        {{jun-global-rng3}}
+.addr   main                            628180
 .addr   reentry-address                 02175f
 .addr   reentry-fail-address            02151e
 
-.addr   pointer-address                 61f180
-.def    command-index       40
+.addr   pointer-address                 {{jun-global-command-summon}}
 
 $main
 :       bb
 :       e0 08
-:       b0 no-esper
+:       90 is-player-character
+:       e2 30
+:       a9 1b
+:       22 $jun-rng3
+:       80 do-summon
 
+.label is-player-character
 :       c2 30
 :       bd 10 30
 :       aa
@@ -20,6 +25,7 @@ $main
 :       e2 10
 :       f0 no-esper
 
+.label do-summon
 :       18
 :       69 36
 :       85 b6

--- a/BeyondChaos/tables/patch_junction_core.txt
+++ b/BeyondChaos/tables/patch_junction_core.txt
@@ -1,78 +1,82 @@
-.addr   jun-checker                         610000
+.addr   jun-checker                         {{jun-global-checker}}
 .addr       character-info                      7e3010
-.addr   jun-checker-y                       6100a0
+.addr       combatant-bits                      7e3018
+.addr   jun-checker-y                       {{jun-global-checker-y}}
 
-.addr   jun-check-whitelist                 610100
-.addr   jun-check-blacklist                 610180
-.addr   jun-check-list                      6101e0
-.addr   jun-check-equip-whitelist           610200
-.addr   jun-check-equip-blacklist           610210
-.addr   jun-check-whitelist-monster-version 610280
-.addr   jun-check-blacklist-monster-version 6102c0
-.addr   jun-check-rage                      610300
+.addr   jun-check-whitelist                 {{jun-global-check-whitelist}}
+.addr   jun-check-blacklist                 {{jun-global-check-blacklist}}
+.addr   jun-check-list                      {{jun-global-check-list}}
+.addr   jun-check-equip-whitelist           {{jun-global-check-equip-whitelist}}
+.addr   jun-check-equip-blacklist           {{jun-global-check-equip-blacklist}}
+.addr   jun-check-whitelist-monster-version {{jun-global-check-whitelist-monster-version}}
+.addr   jun-check-blacklist-monster-version {{jun-global-check-blacklist-monster-version}}
+.addr   jun-check-rage                      {{jun-global-check-rage}}
 .addr       rage-indexes                        7e33a8
-.addr   jun-check-status-whitelist          610340
-.addr   jun-check-status-blacklist          6103a0
-.addr   jun-check-monster-equip-whitelist   610400
-.addr   jun-check-monster-equip-blacklist   610480
+.addr   jun-check-status-whitelist          {{jun-global-check-status-whitelist}}
+.addr   jun-check-status-blacklist          {{jun-global-check-status-blacklist}}
+.addr   jun-check-monster-equip-whitelist   {{jun-global-check-monster-equip-whitelist}}
+.addr   jun-check-monster-equip-blacklist   {{jun-global-check-monster-equip-blacklist}}
 .addr       stealable-items-address         7e3308
 .addr       dropped-items-address           0f3002
-.addr       monster-equip-steal-enabled     6104fc
-.addr       monster-equip-drop-enabled      6104fe
+.addr       monster-equip-steal-enabled     {{jun-global-monster-equip-steal-enabled}}
+.addr       monster-equip-drop-enabled      {{jun-global-monster-equip-drop-enabled}}
 
-.addr   jun-always-whitelist                611000
-.addr   jun-character-whitelist             611800
-.addr   jun-character-blacklist             611c00
-.addr   jun-esper-whitelist                 612000
-.addr   jun-esper-blacklist                 612400
-.addr   jun-status-whitelist                612800
-.addr   jun-status-blacklist                612c00
-.addr   jun-equip-whitelist                 613000
-.addr   jun-equip-blacklist                 613800
-.addr   jun-monster-whitelist               614000
-.addr   jun-monster-blacklist               614800
+.addr   jun-always-whitelist                {{jun-global-always-whitelist}}
+.addr   jun-character-whitelist             {{jun-global-character-whitelist}}
+.addr   jun-character-blacklist             {{jun-global-character-blacklist}}
+.addr   jun-esper-whitelist                 {{jun-global-esper-whitelist}}
+.addr   jun-esper-blacklist                 {{jun-global-esper-blacklist}}
+.addr   jun-status-whitelist                {{jun-global-status-whitelist}}
+.addr   jun-status-blacklist                {{jun-global-status-blacklist}}
+.addr   jun-equip-whitelist                 {{jun-global-equip-whitelist}}
+.addr   jun-equip-blacklist                 {{jun-global-equip-blacklist}}
+.addr   jun-monster-whitelist               {{jun-global-monster-whitelist}}
+.addr   jun-monster-blacklist               {{jun-global-monster-blacklist}}
 
-.addr   jun-mult                            610800
-.addr   jun-divide                          610860
-.addr   jun-rng1                            610820
-.addr   jun-rng2                            610830
-.addr   jun-rng3                            610840
-.addr   jun-select-bit                      6108a0
-.addr   jun-bit-to-index                    6108d0
-.addr   jun-count-bits                      6108c0
+.addr   jun-mult                            {{jun-global-mult}}
+.addr   jun-divide                          {{jun-global-divide}}
+.addr   jun-rng1                            {{jun-global-rng1}}
+.addr   jun-rng2                            {{jun-global-rng2}}
+.addr   jun-rng2-noluck                     {{jun-global-rng2-noluck}}
+.addr   jun-rng3                            {{jun-global-rng3}}
+.addr   jun-select-bit                      {{jun-global-select-bit}}
+.addr   jun-bit-to-index                    {{jun-global-bit-to-index}}
+.addr   jun-count-bits                      {{jun-global-count-bits}}
+.addr   jun-bit-to-combatant-index          {{jun-global-bit-to-combatant-index}}
 
 .addr   jun-dispatcher-address-c2           02af18
-.addr   jun-dispatcher-return               610fff
-.addr   jun-queue-command                   610ff0
+.addr   jun-dispatcher-return               {{jun-global-dispatcher-return}}
+.addr   jun-queue-command                   {{jun-global-queue-command}}
 .addr       command-queue-routine               024eb2
-.addr   jun-queue-self-spell                610fc0
+.addr   jun-queue-self-spell                {{jun-global-queue-self-spell}}
 .addr       self-spell-queue-routine            024e91
-.addr   jun-reload-character-commands       610f80
+.addr   jun-reload-character-commands       {{jun-global-reload-character-commands}}
 .addr       load-character-commands-routine     02532c
 .addr       command-change-byte-address     18500a
-.addr   jun-force-update                    610fe0
+.addr   jun-force-update                    {{jun-global-force-update}}
 .addr       force-update-routine                02083f
-.addr   jun-generic-dispatch                610f00
+.addr   jun-generic-dispatch                {{jun-global-generic-dispatch}}
 
-.addr   jun-check-entity-living             610600
+.addr   jun-check-entity-living             {{jun-global-check-entity-living}}
 .addr       living-characters                   7e3a74
 .addr       living-enemies                      7e3a75
-.addr   jun-check-entity-present            610640
+.addr   jun-check-entity-present            {{jun-global-check-entity-present}}
 .addr       present-characters                  7e3a78
 .addr       present-enemies                     7e3a79
-.addr   jun-check-entity-can-act            6106c0
-.addr   jun-check-count-all-living          610680
-.addr   jun-deduct-item-if-possible         610740
-.addr       jun-check-inventory                 610700
+.addr   jun-check-entity-can-act            {{jun-global-check-entity-can-act}}
+.addr   jun-check-count-all-living          {{jun-global-check-count-all-living}}
+.addr   jun-deduct-item-if-possible         {{jun-global-deduct-item-if-possible}}
+.addr       jun-check-inventory                 {{jun-global-check-inventory}}
 .addr           inventory-address                   7e2686
 .addr           inventory-quantity-address          7e2689
-.addr   jun-set-target-allies               610780
-.addr   jun-set-target-counter              6107c0
-.addr   jun-check-are-same-team             6105e0
-.addr   jun-get-equipped-esper              610900
-.addr   jun-check-is-damage-over-time       610920
-.addr   jun-check-spell-targets-ally        610960
+.addr   jun-set-target-allies               {{jun-global-set-target-allies}}
+.addr   jun-set-target-counter              {{jun-global-set-target-counter}}
+.addr   jun-check-are-same-team             {{jun-global-check-are-same-team}}
+.addr   jun-get-equipped-esper              {{jun-global-get-equipped-esper}}
+.addr   jun-check-is-damage-over-time       {{jun-global-check-is-damage-over-time}}
+.addr   jun-check-spell-targets-ally        {{jun-global-check-spell-targets-ally}}
 .addr       spell-data-address                  046ac0
+.addr   jun-compare-x-y                     {{jun-global-compare-x-y}}
 
 .addr   bits                                00bafc
 .addr   wide-bits                           00b4f3
@@ -80,11 +84,41 @@
 
 .addr   monster-indexes                     7e1ff9
 
-.def    jun-data-bank       61
+.def    jun-data-bank       {{jun-data-bank}}
 
 # PARAMETERS:   junction index in A, (actor index * 2) in X
 # RETURNS:      sets zero bit if check passes, otherwise clears zero bit
 $jun-checker
+:   20 @jun-checker-body,2
+:   f0 jun-checker-wrapper-fail
+.label jun-checker-wrapper-success
+:   08
+:   c2 30
+:   48 da
+:   29 ff 00
+:   c9 {{jun-index-luck-font}} 00
+:   f0 no-jammer
+:   c9 {{jun-index-luck-sink}} 00
+:   f0 no-jammer
+:   a9 {{jun-index-junction-jammer}} 00
+:   f0 no-jammer
+:   ad $living-characters,2
+:   f0 no-jammer
+:   22 $jun-select-bit
+:   22 $jun-bit-to-combatant-index
+:   a9 {{jun-index-junction-jammer}} 00
+:   20 @jun-checker-body,2
+:   f0 no-jammer
+:   fa 68 28
+:   e2 02
+:   6b
+.label no-jammer
+:   fa 68 28
+:   6b
+.label jun-checker-wrapper-fail
+:   6b
+
+.label jun-checker-body
 :   48 eb 48 eb da 5a 8b 08
 :   e2 30
 :   e0 08
@@ -156,11 +190,11 @@ $jun-checker
 .label final-exit-check-failed
 :   28 ab 7a fa 68 eb 68
 :   e2 02
-:   6b
+:   60
 .label final-exit-check-passed
 :   28 ab 7a fa 68 eb 68
 :   c2 02
-:   6b
+:   60
 
 $jun-check-list
 #   X   - list address
@@ -270,7 +304,7 @@ $jun-check-whitelist-monster-version
 :   20 $jun-check-list,2
 :   d0 found-whitelist-monster-version
 
-:   a9 {{every_monster_index}}
+:   a9 {{every-monster-index}}
 :   0a
 :   a8
 :   be $jun-monster-whitelist,2
@@ -531,7 +565,7 @@ $jun-check-blacklist
 :   60
 
 $jun-check-blacklist-monster-version
-:   a9 {{every_monster_index}}
+:   a9 {{every-monster-index}}
 :   0a
 :   a8
 :   be $jun-monster-blacklist,2
@@ -635,20 +669,87 @@ $jun-divide
 
 # 0 or 1 (in carry bit)
 $jun-rng1
-:   48
+:   48 08
+:   e2 20
 :   22 $jun-rng2
-:   4a
-:   68
+:   0a
+:   90 rng1-carry-clear
+:   28 68
+:   38
+:   6b
+.label rng1-carry-clear
+:   28 68
+:   18
 :   6b
 
 # 0 to 255
 $jun-rng2
 :   da 08
 :   e2 30
+:   a9 {{jun-index-luck-sink}}
+:   22 $jun-check-count-all-living
+:   48
+:   a9 {{jun-index-luck-font}}
+:   22 $jun-check-count-all-living
+:   38
+:   e3 01
+:   83 01
+:   30 rng2-sink-mode
+
+.label rng2-font-mode
+:   fa
+:   20 @jun-rng2-raw,2
+:   48
+.label rng2-font-loop
+:   ca
+:   30 rng2-exit
+#:   20 @jun-rng2-raw,2
+#:   4a
+#:   90 rng2-font-loop
+:   20 @jun-rng2-raw,2
+:   c3 01
+:   b0 rng2-font-loop
+:   83 01
+:   80 rng2-font-loop
+
+.label rng2-sink-mode
+:   68
+:   49 ff
+:   1a
+:   aa
+:   20 @jun-rng2-raw,2
+:   48
+.label rng2-sink-loop
+:   ca
+:   30 rng2-exit
+#:   20 @jun-rng2-raw,2
+#:   4a
+#:   90 rng2-sink-loop
+:   20 @jun-rng2-raw,2
+:   c3 01
+:   90 rng2-sink-loop
+:   83 01
+:   80 rng2-sink-loop
+
+.label rng2-exit
+:   68
+:   28 fa
+:   6b
+.label jun-rng2-raw
+:   da 08
+:   e2 30
 :   e6 be
 :   a6 be
 :   bf 00 fd c0
 :   28 fa
+:   60
+
+$jun-rng2-noluck
+:   da
+:   e6 be
+:   a6 be
+:   bf 00 fd c0
+:   fa
 :   6b
 
 # 0 to A-1
@@ -658,9 +759,12 @@ $jun-rng3
 :   e2 30
 :   eb
 :   48
-:   e6 be
-:   a6 be
-:   bf 00 fd c0
+:   eb
+:   48
+:   22 $jun-rng2
+:   eb
+:   68
+:   eb
 :   22 $jun-mult
 :   68
 :   eb
@@ -730,6 +834,9 @@ $jun-check-entity-living
 :   f0 check-living-no
 :   bd f9 3e
 :   89 20
+:   d0 check-living-no
+:   bd f9 3e
+:   89 80
 :   d0 check-living-no
 :   80 check-living-yes
 .label check-living-is-monster
@@ -965,8 +1072,9 @@ $jun-force-update
 :       6b
 
 $jun-generic-dispatch
-:       48 08
+:       08
 :       c2 20
+:       48
 :       62 generic-dispatch-reentry,2
 :       f4 $jun-dispatcher-address-c2,2
 # push bank (high byte)
@@ -975,14 +1083,16 @@ $jun-generic-dispatch
 :       48
 # push low bytes of target routine
 :       c2 20
-:       a3 0b
+:       a3 0c
 :       3a
 :       48
 # restore status register and accumulator
 :       e2 20
-:       a3 08
-:       48 28
+:       a3 0a
+:       48
+:       c2 20
 :       a3 09
+:       28
 :       6b
 .label generic-dispatch-reentry
 # automatically handle removing target from stack
@@ -991,10 +1101,10 @@ $jun-generic-dispatch
 :       c2 20
 :       48
 # shift call address
+:       a3 08
+:       83 0a
 :       a3 07
 :       83 09
-:       a3 06
-:       83 08
 # shift accumulator
 :       a3 01
 :       83 04
@@ -1003,10 +1113,11 @@ $jun-generic-dispatch
 :       e2 20
 :       a3 03
 :       83 07
+:       83 08
 :       c2 20
 :       68 68 68
 :       eb
-:       28
+:       28 28
 :       6b
 
 $jun-check-are-same-team
@@ -1050,9 +1161,16 @@ $jun-get-equipped-esper
 $jun-check-is-damage-over-time
 :       08
 :       c2 20
+:       8a
+:       c9 13 00
+:       b0 dot-bad-indexes
+:       98
+:       c9 13 00
+:       b0 dot-bad-indexes
 :       b9 18 30
 :       3c 18 30
 :       f0 dot-not-targeting-self
+.label dot-bad-indexes
 :       e2 20
 :       ad 7c 3a
 :       c9 22
@@ -1091,6 +1209,37 @@ $jun-check-spell-targets-ally
 :       28 fa 68
 :       c2 02
 :       6b
+
+$jun-compare-x-y
+:       08
+:       c2 30
+:       48 da
+:       98
+:       c3 01
+:       f0 jun-compare-x-y-are-equal
+:       fa 68
+:       28
+:       c2 02
+:       6b
+.label jun-compare-x-y-are-equal
+:       fa 68
+:       28
+:       e2 02
+:       6b
+
+$jun-bit-to-combatant-index
+:   08
+:   c2 30
+:   a2 12 00
+.label bit-to-combatant-loop
+:   dd $combatant-bits,2
+:   f0 bit-to-combatant-found
+:   ca ca
+:   10 bit-to-combatant-loop
+:   a2 ff ff
+.label bit-to-combatant-found
+:   28
+:   6b
 
 VALIDATION
 

--- a/BeyondChaos/tables/patch_junction_cover.txt
+++ b/BeyondChaos/tables/patch_junction_cover.txt
@@ -1,8 +1,8 @@
-.addr   jun-checker                     610000
-.addr   jun-check-entity-living         610600
-.addr   jun-rng1                        610820
-.addr   jun-select-bit                  6108a0
-.addr   jun-bit-to-index                6108d0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-select-bit                  {{jun-global-select-bit}}
+.addr   jun-bit-to-index                {{jun-global-bit-to-index}}
 
 .addr   main                            621e00
 .addr   check-paladins                  621ea0
@@ -11,9 +11,6 @@
 .addr   return-love-token               021259
 .addr   return-no-bodyguards            02125f
 .addr   wide-bits                       00b4f3
-
-.def    jun-index-true-paladin  9e
-.def    jun-index-popular       9f
 
 021254: 5c $main
 
@@ -27,7 +24,7 @@ $main
 :       10 exit-with-bodyguard
 .label no-paladins
 :       bb
-:       a9 jun-index-popular 00
+:       a9 {{jun-index-popular}} 00
 :       22 $jun-checker
 :       f0 no-bodyguards
 :       20 $check-popular,2
@@ -44,7 +41,7 @@ $check-paladins
 :       48
 :       3f $wide-bits
 :       f0 paladins-skip
-:       a9 jun-index-true-paladin 00
+:       a9 {{jun-index-true-paladin}} 00
 :       22 $jun-checker
 :       d0 paladins-skip
 :       68
@@ -110,9 +107,9 @@ $get-potential-bodyguards
 :       1f $wide-bits
 :       5f $wide-bits
 :       22 $jun-rng1
-:       90 potential-force-allies-only
+:       b0 potential-force-allies-only
 :       48
-:       a9 jun-index-popular 00
+:       a9 {{jun-index-popular}} 00
 :       22 $jun-checker
 :       d0 potential-pull-exit
 :       68

--- a/BeyondChaos/tables/patch_junction_critical_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_critical_trigger.txt
@@ -1,7 +1,7 @@
-.addr   jun-checker                     610000
-.addr   jun-queue-command               610ff0
-.addr   jun-queue-self-spell            610fc0
-.addr   jun-set-target-counter          6107c0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
+.addr   jun-queue-self-spell            {{jun-global-queue-self-spell}}
+.addr   jun-set-target-counter          {{jun-global-set-target-counter}}
 .addr   main                            620480
 
 .addr   spell-indexes-address           620580
@@ -9,20 +9,15 @@
 .addr   command-indexes-address         620590
 .def    command-indexes-list    0b 18 40 41 15
 
-.def    first-spell-index           20
+.def    first-spell-index           {{jun-index-critical-haste=20}}
 .def    overflow-spell-index        2e
-.def    first-command-index         30
+.def    first-command-index         {{jun-index-critical-runic=30}}
 .def    overflow-command-index      35
 
 .addr   do-self-spell                   625000
 .addr   do-command                      626000
 
-.def    jun-index-morph             38
-.def    jun-index-revenge           39
-.def    jun-index-escape            3a
-
 .def    escape-spell-index          c2
-.def    revenge-spell-index         92
 
 020a5d: 22 $main
 :       ea ea
@@ -60,7 +55,7 @@ $main
 :       ad f6 1c
 :       c9 10
 :       90 no-morph
-:       a9 jun-index-morph
+:       a9 {{jun-index-critical-morph}}
 :       22 $jun-checker
 :       f0 no-morph
 :       a9 03
@@ -68,21 +63,10 @@ $main
 :       22 $jun-queue-command
 
 .label no-morph
-:       a9 jun-index-revenge
-:       22 $jun-checker
-:       f0 no-revenge
-:       22 $jun-set-target-counter
-:       a9 44
-:       8d 7a 3a
-:       a9 revenge-spell-index
-:       8d 7b 3a
-:       22 $jun-queue-command
-
-.label no-revenge
 :       a9 06
 :       24 b1
 :       d0 cant-escape
-:       a9 jun-index-escape
+:       a9 {{jun-index-critical-escape}}
 :       22 $jun-checker
 :       f0 cant-escape
 :       a9 escape-spell-index

--- a/BeyondChaos/tables/patch_junction_damage_modification.txt
+++ b/BeyondChaos/tables/patch_junction_damage_modification.txt
@@ -1,9 +1,15 @@
-.addr   jun-checker                     610000
-.addr   jun-check-entity-living         610600
-.addr   jun-check-count-all-living      610680
-.addr   jun-divide                      610860
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-check-entity-present        {{jun-global-check-entity-present}}
+.addr   jun-check-count-all-living      {{jun-global-check-count-all-living}}
+.addr   jun-divide                      {{jun-global-divide}}
+.addr   jun-generic-dispatch            {{jun-global-generic-dispatch}}
+.addr   long-multiplication-address     0247b7
+.addr   long-division-address           02b8f3
+
 .addr   main                            620300
 .addr   main-misc                       620600
+.addr   do-life-force                   622a00
 .addr   multiply-damage                 6205e0
 .addr   check-element                   6212e0
 .addr   check-esper                     620e20
@@ -19,45 +25,12 @@
 .addr   get-esper-data-offset           621ad0
 
 .addr   background-dances-address       2d8e5b
+.addr   hp-growths-address              26f4a0
 
-.def    jun-index-fire          10
-.def    jun-index-ice           11
-.def    jun-index-bolt          12
-.def    jun-index-poison        13
-.def    jun-index-wind          14
-.def    jun-index-pearl         15
-.def    jun-index-earth         16
-.def    jun-index-water         17
-.def    jun-index-fire-font     60
-.def    jun-index-ice-font      61
-.def    jun-index-bolt-font     62
-.def    jun-index-poison-font   63
-.def    jun-index-wind-font     64
-.def    jun-index-pearl-font    65
-.def    jun-index-earth-font    66
-.def    jun-index-water-font    67
-.def    jun-index-fire-sink     68
-.def    jun-index-ice-sink      69
-.def    jun-index-bolt-sink     6a
-.def    jun-index-poison-sink   6b
-.def    jun-index-wind-sink     6c
-.def    jun-index-pearl-sink    6d
-.def    jun-index-earth-sink    6e
-.def    jun-index-water-sink    6f
-
-.def    jun-index-esper         49
-.def    jun-index-nuke          4a
-.def    jun-index-nuke-font     4b
-.def    jun-index-nuke-sink     4c
-.def    jun-index-phys          4d
-.def    jun-index-phys-font     4e
-.def    jun-index-phys-sink     4f
-
-.def    jun-index-esper-attack  9a
-
-.def    jun-index-loner         3c
-.def    jun-index-crisis-arm    3d
-.def    jun-index-gaia-boost    a0
+.addr   character-base-level-address    7e1608
+.addr   character-info                  7e3010
+.addr   current-hp-address              7e3bf4
+.addr   max-hp-address                  7e3c1c
 
 .def    ramuh-index             36
 .def    phoenix-index-plus-one  51
@@ -70,7 +43,7 @@ $main
 
 :       20 $check-has-esper,2
 :       f0 no-esper-main
-:       a9 jun-index-esper-attack
+:       a9 {{jun-index-esper-attack}}
 :       22 $jun-checker
 :       f0 no-esper-main
 :       da
@@ -81,21 +54,21 @@ $main
 :       fa
 
 .label no-esper-main
-:       a9 jun-index-fire
+:       a9 {{jun-index-boost-fire}}
 :       20 $check-element,2
-:       a9 jun-index-ice
+:       a9 {{jun-index-boost-ice}}
 :       20 $check-element,2
-:       a9 jun-index-bolt
+:       a9 {{jun-index-boost-bolt}}
 :       20 $check-element,2
-:       a9 jun-index-poison
+:       a9 {{jun-index-boost-poison}}
 :       20 $check-element,2
-:       a9 jun-index-wind
+:       a9 {{jun-index-boost-wind}}
 :       20 $check-element,2
-:       a9 jun-index-pearl
+:       a9 {{jun-index-boost-pearl}}
 :       20 $check-element,2
-:       a9 jun-index-earth
+:       a9 {{jun-index-boost-earth}}
 :       20 $check-element,2
-:       a9 jun-index-water
+:       a9 {{jun-index-boost-water}}
 :       20 $check-element,2
 
 :       20 $check-esper,2
@@ -112,12 +85,18 @@ $main
 :       fa
 :       2c a1 11
 :       f0 no-gaia-boost
-:       a9 jun-index-gaia-boost
+:       a9 {{jun-index-gaia-boost}}
 :       22 $jun-checker
 :       f0 no-gaia-boost
 :       20 $boost-damage-half,2
 
 .label no-gaia-boost
+:       a9 {{jun-index-life-force}}
+:       22 $jun-checker
+:       f0 no-life-force
+:       20 $do-life-force,2
+
+.label no-life-force
 :       7a fa 68
 :       ad a2 11
 :       4a
@@ -130,7 +109,7 @@ $main-misc
 :       da 08
 :       c2 20
 
-:       a9 jun-index-loner 00
+:       a9 {{jun-index-loner}} 00
 :       22 $jun-checker
 :       f0 no-loner
 
@@ -176,7 +155,7 @@ $main-misc
 :       fa da
 
 .label no-loner
-:       a9 jun-index-crisis-arm 00
+:       a9 {{jun-index-crisis-arm}} 00
 :       22 $jun-checker
 :       f0 no-junction
 
@@ -189,6 +168,202 @@ $main-misc
 
 .label no-junction
 :       28 fa
+:       60
+
+$do-life-force
+:       08
+:       c2 30
+:       48 da 5a
+:       20 @lf-get-expected-hp,2
+:       48
+:       20 @lf-get-current-hp,2
+:       48
+:       ad b0 11
+:       c3 01
+:       90 lf-damage-is-less
+:       fa
+:       80 lf-begin-multiply
+.label lf-damage-is-less
+:       aa
+:       68
+.label lf-begin-multiply
+:       7a
+:       20 @lf-multiply-damage,2
+
+:       48
+:       18
+:       63 01
+:       90 lf-no-carry-1
+:       a9 ff ff
+.label lf-no-carry-1
+:       18
+:       63 01
+:       90 lf-no-carry-2
+:       a9 ff ff
+.label lf-no-carry-2
+:       83 01
+:       68
+:       8d b0 11
+
+:       7a fa 68
+:       28
+:       60
+
+# hp-growths-address
+.label lf-get-expected-hp
+:       da
+:       a9 00 00
+:       48
+:       e0 08 00
+:       b0 lf-get-expected-is-monster
+:       a0 06 00
+.label lf-get-expected-human-loop
+:       bb
+:       22 $jun-check-entity-present
+:       d0 lf-get-expected-human-is-present
+:       a3 03
+:       aa
+.label lf-get-expected-human-is-present
+:       20 @lf-calculate-expected-hp,2
+:       63 01
+:       83 01
+:       88 88
+:       10 lf-get-expected-human-loop
+:       80 lf-get-expected-exit
+.label lf-get-expected-is-monster
+:       a0 0a 00
+.label lf-get-expected-monster-loop
+:       98
+:       18
+:       69 08 00
+:       aa
+:       22 $jun-check-entity-present
+:       f0 lf-get-expected-monster-skip
+:       bd $max-hp-address,2
+:       4a 4a 4a
+:       63 01
+:       83 01
+.label lf-get-expected-monster-skip
+:       88 88
+:       10 lf-get-expected-monster-loop
+.label lf-get-expected-exit
+:       68
+:       d0 lf-get-expected-nonzero
+:       1a
+.label lf-get-expected-nonzero
+:       fa
+:       60
+
+.label lf-calculate-expected-hp
+:       5a
+:       a9 23 00
+:       48
+:       bc $character-info,2
+:       b9 $character-base-level-address,2
+:       29 ff 00
+:       3a 3a
+:       30 lf-calculate-expected-exit
+:       aa
+.label lf-calculate-expected-loop
+:       bf $hp-growths-address
+:       29 ff 00
+:       18
+:       63 01
+:       90 lf-calculate-expected-no-overflow
+:       a9 0f 27
+.label lf-calculate-expected-no-overflow
+:       83 01
+:       ca
+:       10 lf-calculate-expected-loop
+.label lf-calculate-expected-exit
+:       68
+:       7a
+:       60
+
+.label lf-get-current-hp
+:       da
+:       a9 00 00
+:       48
+:       e0 08 00
+:       b0 lf-get-current-is-monster
+:       a0 06 00
+.label lf-get-current-human-loop
+:       bb
+:       22 $jun-check-entity-present
+:       f0 lf-get-current-human-skip
+:       a3 01
+:       7d $current-hp-address,2
+:       83 01
+.label lf-get-current-human-skip
+:       88 88
+:       10 lf-get-current-human-loop
+:       80 lf-get-current-exit
+.label lf-get-current-is-monster
+:       a0 0a 00
+.label lf-get-current-monster-loop
+:       98
+:       18
+:       69 08 00
+:       aa
+:       22 $jun-check-entity-present
+:       f0 lf-get-current-monster-skip
+:       bd $current-hp-address,2
+:       4a 4a 4a
+:       63 01
+:       83 01
+.label lf-get-current-monster-skip
+:       88 88
+:       10 lf-get-current-monster-loop
+.label lf-get-current-exit
+:       68
+:       fa
+:       60
+
+.label lf-multiply-damage
+:       48
+:       8a
+.label lf-multiply-damage-loop
+:       4a
+:       89 00 ff
+:       f0 lf-multiply-damage-end-loop
+:       48
+:       98
+:       4a
+:       a8
+:       68
+:       80 lf-multiply-damage-loop
+.label lf-multiply-damage-end-loop
+:       85 e8
+:       68
+:       f4 $long-multiplication-address,2
+:       22 $jun-generic-dispatch
+.label lf-multiply-damage-2nd-loop
+:       a5 e9
+:       89 00 ff
+:       f0 lf-multiply-damage-end-2nd-loop
+:       e2 20
+:       18
+:       46 ea
+:       66 e9
+:       66 e8
+:       c2 20
+:       98
+:       4a
+:       a8
+:       80 lf-multiply-damage-2nd-loop
+.label lf-multiply-damage-end-2nd-loop
+:       a5 e8
+:       85 2c
+:       98
+:       c9 00 00
+:       d0 lf-nonzero-divisor
+:       1a
+.label lf-nonzero-divisor
+:       85 2e
+:       f4 $long-division-address,2
+:       22 $jun-generic-dispatch
+:       c2 20
+:       a5 30
 :       60
 
 $multiply-damage
@@ -227,7 +402,7 @@ $check-element
 :       29 07
 :       aa
 :       18
-:       69 jun-index-fire-font
+:       69 {{jun-index-fire-font}}
 :       22 $jun-check-count-all-living
 .label font-loop
 :       3a
@@ -238,7 +413,7 @@ $check-element
 
 :       8a
 :       18
-:       69 jun-index-fire-sink
+:       69 {{jun-index-fire-sink}}
 :       22 $jun-check-count-all-living
 .label sink-loop
 :       3a
@@ -267,7 +442,7 @@ $check-esper
 :       c9 phoenix-index-plus-one
 :       b0 not-esper
 .label is-esper
-:       a9 jun-index-esper
+:       a9 {{jun-index-boost-esper}}
 :       22 $jun-checker
 :       f0 not-esper
 :       20 $boost-damage-half,2
@@ -284,13 +459,13 @@ $check-nuke
 :       89 81
 :       d0 not-nuke
 
-:       a9 jun-index-nuke
+:       a9 {{jun-index-boost-nuke}}
 :       22 $jun-checker
 :       f0 no-nuke-boost
 :       20 $boost-damage-half,2
 .label no-nuke-boost
 
-:       a9 jun-index-nuke-font
+:       a9 {{jun-index-nuke-font}}
 :       22 $jun-check-count-all-living
 .label nuke-font-loop
 :       3a
@@ -299,7 +474,7 @@ $check-nuke
 :       80 nuke-font-loop
 .label end-nuke-font-loop
 
-:       a9 jun-index-nuke-sink
+:       a9 {{jun-index-nuke-sink}}
 :       22 $jun-check-count-all-living
 .label nuke-sink-loop
 :       3a
@@ -316,13 +491,13 @@ $check-phys
 :       89 01
 :       f0 not-phys
 
-:       a9 jun-index-phys
+:       a9 {{jun-index-boost-phys}}
 :       22 $jun-checker
 :       f0 no-phys-boost
 :       20 $boost-damage-half,2
 .label no-phys-boost
 
-:       a9 jun-index-phys-font
+:       a9 {{jun-index-phys-font}}
 :       22 $jun-check-count-all-living
 .label phys-font-loop
 :       3a
@@ -331,7 +506,7 @@ $check-phys
 :       80 phys-font-loop
 .label end-phys-font-loop
 
-:       a9 jun-index-phys-sink
+:       a9 {{jun-index-phys-sink}}
 :       22 $jun-check-count-all-living
 .label phys-sink-loop
 :       3a
@@ -344,7 +519,7 @@ $check-phys
 :       60
 
 $boost-damage-half
-:       48
+:       48 08
 :       c2 20
 :       ad b0 11
 :       4a
@@ -354,12 +529,11 @@ $boost-damage-half
 :       a9 ff ff
 .label no-overflow-half
 :       8d b0 11
-:       e2 20
-:       68
+:       28 68
 :       60
 
 $boost-damage-quarter
-:       48
+:       48 08
 :       c2 20
 :       ad b0 11
 :       4a 4a
@@ -369,12 +543,11 @@ $boost-damage-quarter
 :       a9 ff ff
 .label no-overflow-quarter
 :       8d b0 11
-:       e2 20
-:       68
+:       28 68
 :       60
 
 $reduce-damage-quarter
-:       48
+:       48 08
 :       c2 20
 :       ad b0 11
 :       4a
@@ -383,11 +556,18 @@ $reduce-damage-quarter
 :       18
 :       6d b0 11
 :       8d b0 11
-:       e2 20
-:       68
+:       28 68
 :       60
 
 VALIDATION
 
 02336f: ad a2 11
 :       4a
+
+0247b7: 08
+:       e2 20
+:       64 ea
+
+02b8f3: da
+:       c2 20
+:       64 30

--- a/BeyondChaos/tables/patch_junction_damage_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_damage_trigger.txt
@@ -1,19 +1,23 @@
-.addr   jun-checker                     610000
-.addr   jun-divide                      610860
-.addr   jun-rng1                        610820
-.addr   jun-queue-command               610ff0
-.addr   jun-check-entity-living         610600
-.addr   jun-check-count-all-living      610680
-.addr   jun-deduct-item-if-possible     610740
-.addr   jun-set-target-allies           610780
-.addr   jun-count-bits                  6108c0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-divide                      {{jun-global-divide}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-check-count-all-living      {{jun-global-check-count-all-living}}
+.addr   jun-deduct-item-if-possible     {{jun-global-deduct-item-if-possible}}
+.addr   jun-set-target-allies           {{jun-global-set-target-allies}}
+.addr   jun-set-target-counter          {{jun-global-set-target-counter}}
+.addr   jun-count-bits                  {{jun-global-count-bits}}
+.addr   jun-check-is-damage-over-time   {{jun-global-check-is-damage-over-time}}
+.addr   jun-compare-x-y                 {{jun-global-compare-x-y}}
+
 .addr   main                            620c00
-.addr   main-nihopalaoa                 6210e0
+.addr   main-nihopalaoa                 622960
 .addr   main-calc                       621dc0
 .addr   check-calc                      621c80
 .addr   do-distribute-characters        621d00
 .addr   do-distribute-monsters          621d60
-.addr   check-nihopalaoa                620e80
+.addr   check-nihopalaoa                622940
 .addr   check-heal                      6217a0
 .addr   check-brace                     621280
 .addr   check-catch                     6212a0
@@ -26,28 +30,18 @@
 .addr   reduce-healing-half             620cf0
 .addr   reverse-damage                  620fa0
 .addr   check-precision                 620fc0
-.addr   do-auto-potion                  621100
-.addr   check-nonzero-nonlethal-damage  621160
-.addr   retarget-salve                  621180
+.addr   do-meatbone-auto-potion         621100
+.addr   check-nonzero-nonlethal-damage  621260
+.addr   retarget-salve                  621080
 .addr   do-blood-restriction            6207c0
 
-.def    jun-index-blood             0a
-.def    jun-index-heal-boost        53
-.def    jun-index-heal-font         70
-.def    jun-index-heal-sink         71
-.def    jun-index-reverse           52
-.def    jun-index-chemist           5e
-.def    jun-index-nihopalaoa        5f
-.def    jun-index-precision         5b
-.def    jun-index-catch             77
-.def        throw-index                 08
-.def    jun-index-brace             7f
-.def    jun-index-damage-split      88
-.def    jun-index-distribute        89
-.def    jun-index-auto-potion       80
-.def        jun-index-salve             07
-.def        potion-index                e9
-.def    jun-index-double-time       a3
+.addr   current-hp-address              7e3bf4
+.addr   max-hp-address                  7e3c1c
+
+.def    throw-index                 08
+.def    revenge-spell-index         92
+.def    potion-index                e9
+
 
 
 022af2: 22 $main-nihopalaoa
@@ -74,7 +68,7 @@ $main
 :       20 $check-brace,2
 :       20 $check-catch,2
 
-:       a9 jun-index-double-time 00
+:       a9 {{jun-index-double-time}} 00
 :       22 $jun-checker
 :       f0 no-double-time
 :       20 $reduce-damage-half,2
@@ -85,7 +79,7 @@ $main
 :       29 ff 00
 :       c9 01 00
 :       d0 no-chemist
-:       a9 jun-index-chemist 00
+:       a9 {{jun-index-chemist}} 00
 :       22 $jun-checker
 :       f0 no-chemist
 :       20 $boost-healing-double,2
@@ -96,14 +90,14 @@ $main
 :       29 ff 00
 :       c9 22 00
 :       f0 no-reverse
-:       a9 jun-index-reverse 00
+:       a9 {{jun-index-reverse}} 00
 :       22 $jun-checker
 :       f0 no-reverse
 :       20 $reverse-damage,2
 
 .label no-reverse
 :       20 $check-precision,2
-:       20 $do-auto-potion,2
+:       20 $do-meatbone-auto-potion,2
 
 .label no-junction
 :       b9 d0 33
@@ -119,19 +113,28 @@ $main-nihopalaoa
 :       1c a4 11
 :       a9 04
 :       1c a2 11
+:       a9 80
+:       2c a4 11
+:       d0 nihopalaoa-miss-death-prot
+:       2c aa 11
+:       d0 nihopalaoa-miss-death-prot
+:       80 exit-no-nihopalaoa
+.label nihopalaoa-miss-death-prot
+:       a9 02
+:       0c a2 11
 .label exit-no-nihopalaoa
 :       fa
 :       bf 00 50 d8
 :       6b
 
 $check-heal
-:       a9 jun-index-heal-boost 00
+:       a9 {{jun-index-heal-boost}} 00
 :       22 $jun-checker
 :       f0 no-heal-boost
 :       20 $boost-healing-half,2
 .label no-heal-boost
 
-:       a9 jun-index-heal-font 00
+:       a9 {{jun-index-heal-font}} 00
 :       22 $jun-check-count-all-living
 .label heal-font-loop
 :       3a
@@ -140,7 +143,7 @@ $check-heal
 :       80 heal-font-loop
 .label end-heal-font-loop
 
-:       a9 jun-index-heal-sink 00
+:       a9 {{jun-index-heal-sink}} 00
 :       22 $jun-check-count-all-living
 .label heal-sink-loop
 :       3a
@@ -162,7 +165,7 @@ $do-blood-restriction
 :       a9 01
 :       2c a4 11
 :       f0 no-blood
-:       a9 jun-index-blood
+:       a9 {{jun-index-blood-mage}}
 :       22 $jun-checker
 :       f0 no-blood
 :       c2 20
@@ -187,7 +190,7 @@ $check-brace
 :       b9 a1 3a
 :       89 02 00
 :       f0 no-brace
-:       a9 jun-index-brace 00
+:       a9 {{jun-index-brace}} 00
 :       22 $jun-checker
 :       f0 no-brace
 :       20 $reduce-damage-half,2
@@ -201,7 +204,7 @@ $check-nihopalaoa
 :       a5 b5
 :       c9 01
 :       d0 not-nihopalaoa
-:       a9 jun-index-nihopalaoa
+:       a9 {{jun-index-nihopalaoa}}
 :       22 $jun-checker
 :       f0 not-nihopalaoa
 :       28 68
@@ -230,7 +233,7 @@ $check-precision
 :       fa
 
 :       e2 20
-:       a9 jun-index-precision
+:       a9 {{jun-index-precision}}
 :       22 $jun-checker
 :       f0 no-precision
 
@@ -260,7 +263,7 @@ $check-calc
 :       20 $check-nonzero-nonlethal-damage,2
 :       f0 no-damage-split
 :       bb
-:       a9 jun-index-damage-split 00
+:       a9 {{jun-index-damage-split}} 00
 :       22 $jun-checker
 :       f0 no-damage-split
 :       fa da
@@ -287,20 +290,20 @@ $check-calc
 :       1a
 :       f0 no-distribute
 :       bb
-:       a9 jun-index-distribute 00
+:       a9 {{jun-index-distribute}} 00
 :       22 $jun-checker
 :       f0 no-distribute
 :       b9 e4 33
 :       18
-:       79 f4 3b
-:       d9 1c 3c
+:       79 $current-hp-address,2
+:       d9 $max-hp-address,2
 :       90 no-distribute
 :       38
-:       f9 1c 3c
+:       f9 $max-hp-address,2
 :       48
-:       b9 1c 3c
+:       b9 $max-hp-address,2
 :       38
-:       f9 f4 3b
+:       f9 $current-hp-address,2
 :       99 e4 33
 :       68
 :       c0 08
@@ -425,7 +428,7 @@ $check-catch
 :       c9 throw-index 00
 :       d0 catch-exit
 :       bb
-:       a9 jun-index-catch 00
+:       a9 {{jun-index-catch}} 00
 :       22 $jun-checker
 :       f0 catch-exit
 :       9e d0 33
@@ -543,7 +546,7 @@ $check-nonzero-nonlethal-damage
 :       1a
 :       f0 non-non-is-zero
 :       3a
-:       d9 f4 3b
+:       d9 $current-hp-address,2
 :       b0 non-non-is-lethal
 :       68
 :       c2 02
@@ -555,31 +558,54 @@ $check-nonzero-nonlethal-damage
 :       60
 
 $retarget-salve
-:       a9 jun-index-salve
+:       a9 {{jun-index-salve}}
 :       22 $jun-checker
 :       f0 no-salve
 :       22 $jun-set-target-allies
 .label no-salve
 :       60
 
-$do-auto-potion
+$do-meatbone-auto-potion
 :       da
 
 # check for decisive blow
 :       ad 1a 34
 :       29 ff 00
-:       f0 auto-potion-exit
+:       f0 auto-potion-exit-all
 
 # check for mp damage
 :       a9 80 00
 :       2c a3 11
-:       d0 auto-potion-exit
+:       d0 auto-potion-exit-all
 
 :       20 $check-nonzero-nonlethal-damage,2
-:       f0 auto-potion-exit
+:       f0 auto-potion-exit-all
+
+:       22 $jun-check-is-damage-over-time
+:       d0 auto-potion-exit-all
+
+:       22 $jun-compare-x-y
+:       f0 no-meatbone
 
 :       bb
-:       a9 jun-index-auto-potion 00
+:       b9 $max-hp-address,2
+:       4a 4a 4a
+:       d9 $current-hp-address,2
+:       90 no-meatbone
+:       a9 {{jun-index-meatbone-cut}} 00
+:       22 $jun-checker
+:       f0 no-meatbone
+:       22 $jun-set-target-counter
+:       a5 b8
+:       2d 74 3a
+:       f0 no-meatbone
+:       a9 44 revenge-spell-index
+:       8d 7a 3a
+:       22 $jun-queue-command
+
+.label no-meatbone
+:       bb
+:       a9 {{jun-index-auto-potion}} 00
 :       22 $jun-checker
 :       f0 auto-potion-exit
 
@@ -588,6 +614,7 @@ $do-auto-potion
 :       90 skip-monster-rng-check
 :       22 $jun-rng1
 :       90 do-not-deduct-item
+.label auto-potion-exit-all
 :       80 auto-potion-fail
 .label skip-monster-rng-check
 :       a9 potion-index 00

--- a/BeyondChaos/tables/patch_junction_death_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_death_trigger.txt
@@ -1,19 +1,20 @@
-.addr   jun-checker                     610000
-.addr   jun-queue-command               610ff0
-.addr   jun-set-target-counter          6107c0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
+.addr   jun-set-target-counter          {{jun-global-set-target-counter}}
 
 .addr   main                            621700
 .addr   main-rippler-instant-death      6216c0
 
-.def    jun-index-immortal          90
-.def    jun-index-spiraler          91
-.def    jun-index-esper             92
-.def    jun-index-rippler           93
+# Since the "has died" flag can be reset for monsters, the
+# "update menu" flag 7e3a58 is repurposed here
+.addr   character-died-flag             7e3a56
+.addr   monster-died-flag               7e3a58
+
 .def    chokesmoke-index            a6
 .def    spiraler-index              63
 .def    rippler-index               9e
-.def    summon-command-index        40
-.def    final-attack-command-index  44
+.def    summon-command-index        {{jun-command-index-summon}}
+.def    final-attack-command-index  {{jun-command-index-final-attack}}
 
 .def    death-bit                   80 00
 .def    death-prot-bit              04 00
@@ -44,14 +45,14 @@ $main
 :       85 b8
 :       e2 20
 
-:       a9 jun-index-immortal
+:       a9 {{jun-index-immortal}}
 :       22 $jun-checker
 :       f0 no-immortal
 :       a9 chokesmoke-index
 :       20 @queue-final-attack,2
 
 .label no-immortal
-:       a9 jun-index-spiraler
+:       a9 {{jun-index-final-spiral}}
 :       22 $jun-checker
 :       f0 no-spiraler
 :       a9 spiraler-index
@@ -59,12 +60,11 @@ $main
 
 .label no-spiraler
 :       c2 20
-:       b9 18 30
-:       2c 56 3a
+:       20 @check-already-death,2
 :       d0 already-death-trigger
 :       e2 20
 
-:       a9 jun-index-esper
+:       a9 {{jun-index-final-esper}}
 :       22 $jun-checker
 :       f0 no-esper
 
@@ -78,7 +78,7 @@ $main
 :       22 $jun-queue-command
 
 .label no-esper
-:       a9 jun-index-rippler
+:       a9 {{jun-index-final-ripple}}
 :       22 $jun-checker
 :       f0 no-rippler
 
@@ -104,6 +104,15 @@ $main
 :       22 $jun-queue-command
 :       60
 
+.label check-already-death
+:       b9 18 30
+:       e0 08
+:       b0 already-death-is-monster
+:       2c $character-died-flag,2
+:       60
+.label already-death-is-monster
+:       0c $monster-died-flag,2
+:       60
 
 $main-rippler-instant-death
 :       bd a1 3a

--- a/BeyondChaos/tables/patch_junction_deaths_door.txt
+++ b/BeyondChaos/tables/patch_junction_deaths_door.txt
@@ -1,8 +1,6 @@
-.addr   jun-checker                     610000
-.addr   jun-check-count-all-living      610680
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-count-all-living      {{jun-global-check-count-all-living}}
 .addr   main                            620c80
-
-.def    jun-index-deaths-door           55
 
 0233bd: 22 $main
 
@@ -19,7 +17,7 @@ $main
 :       c9 01
 :       f0 condemned-case
 
-:       a9 jun-index-deaths-door
+:       a9 {{jun-index-deaths-door}}
 :       22 $jun-checker
 :       f0 exit-miss
 
@@ -45,7 +43,7 @@ $main
 :       6b
 
 .label condemned-case
-:       a9 jun-index-deaths-door
+:       a9 {{jun-index-deaths-door}}
 :       22 $jun-check-count-all-living
 :       c9 00
 :       f0 exit-miss

--- a/BeyondChaos/tables/patch_junction_dog.txt
+++ b/BeyondChaos/tables/patch_junction_dog.txt
@@ -1,12 +1,10 @@
-.addr   jun-checker-y               6100a0
+.addr   jun-checker-y               {{jun-global-checker-y}}
 .addr   main                        620240
-
-.def    jun-index           3f
 
 022282: 22 $main
 
 $main
-:       a9 jun-index
+:       a9 {{jun-index-dog}}
 :       22 $jun-checker-y
 :       f0 exit-normal
 :       b9 f9 3e

--- a/BeyondChaos/tables/patch_junction_double_ap.txt
+++ b/BeyondChaos/tables/patch_junction_double_ap.txt
@@ -1,8 +1,6 @@
-.addr   jun-checker-y                   6100a0
+.addr   jun-checker-y                   {{jun-global-checker-y}}
 .addr   main                            621580
 .addr   restore-normal-magic-points     620560
-
-.def    jun-index           3e
 
 025e2f: 22 $main
 :       ea
@@ -16,7 +14,7 @@ $main
 :       f0 exit-main
 
 :       48
-:       a9 jun-index
+:       a9 {{jun-index-double-ap}}
 :       22 $jun-checker-y
 :       f0 no-double
 :       68

--- a/BeyondChaos/tables/patch_junction_double_time.txt
+++ b/BeyondChaos/tables/patch_junction_double_time.txt
@@ -1,7 +1,5 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            620ba0
-
-.def    jun-index-double-time       a3
 
 0201be: 22 $main
 :       ea ea ea ea
@@ -12,7 +10,7 @@ $main
 :       de 19 32
 :       6b
 .label check-double-time
-:       a9 jun-index-double-time
+:       a9 {{jun-index-double-time}}
 :       22 $jun-checker
 :       f0 exit-main
 :       a9 80

--- a/BeyondChaos/tables/patch_junction_elemental_pierce.txt
+++ b/BeyondChaos/tables/patch_junction_elemental_pierce.txt
@@ -1,7 +1,7 @@
-.addr   jun-checker                             610000
-.addr   jun-rng2                                610830
-.addr   jun-mult                                610800
-.addr   jun-check-is-damage-over-time           610920
+.addr   jun-checker                             {{jun-global-checker}}
+.addr   jun-rng2                                {{jun-global-rng2}}
+.addr   jun-mult                                {{jun-global-mult}}
+.addr   jun-check-is-damage-over-time           {{jun-global-check-is-damage-over-time}}
 .addr   main                                    621340
 .addr   main-esper-attack-misc-effect           621b00
 .addr   fix-force-field                         6203a0
@@ -17,17 +17,7 @@
 .addr   return-force-field-nullify              020bfa
 .addr   bits                                    00bafc
 
-.def    jun-index-fire          18
-.def    jun-index-ice           19
-.def    jun-index-bolt          1a
-.def    jun-index-poison        1b
-.def    jun-index-wind          1c
-.def    jun-index-pearl         1d
-.def    jun-index-earth         1e
-.def    jun-index-water         1f
-.def    jun-index-prism-wall    79
-.def    jun-index-art-license   96
-.def    jun-index-esper-attack  9a
+.def    esper-attack-rate                       40
 
 020b8e: 5c $main-esper-attack-misc-effect
 :       ea
@@ -44,7 +34,7 @@ $main-esper-attack-misc-effect
 :       d0 no-esper-attack-misc-junction
 :       20 $check-has-esper,2
 :       f0 no-esper-attack-misc-junction
-:       a9 jun-index-esper-attack
+:       a9 {{jun-index-esper-attack}}
 :       22 $jun-checker
 :       f0 no-esper-attack-misc-junction
 :       da
@@ -53,8 +43,8 @@ $main-esper-attack-misc-effect
 :       29 03
 :       0c a4 11
 :       22 $jun-rng2
-:       29 03
-:       d0 esper-attack-misc-cleanup
+:       c9 esper-attack-rate
+:       b0 esper-attack-misc-cleanup
 
 :       c2 20
 :       bf 04 00 c4
@@ -104,7 +94,7 @@ $main
 
 :       ec 17 34
 :       d0 not-sketching
-:       a9 jun-index-art-license
+:       a9 {{jun-index-art-license}}
 :       22 $jun-checker
 :       f0 not-sketching
 :       64 10
@@ -112,7 +102,7 @@ $main
 .label not-sketching
 :       20 $check-has-esper,2
 :       f0 no-esper-main
-:       a9 jun-index-esper-attack
+:       a9 {{jun-index-esper-attack}}
 :       22 $jun-checker
 :       f0 no-esper-main
 :       da
@@ -130,21 +120,21 @@ $main
 
 .label elemental
 :       fa da
-:       a9 jun-index-fire
+:       a9 {{jun-index-pierce-fire}}
 :       20 $check-element,2
-:       a9 jun-index-ice
+:       a9 {{jun-index-pierce-ice}}
 :       20 $check-element,2
-:       a9 jun-index-bolt
+:       a9 {{jun-index-pierce-bolt}}
 :       20 $check-element,2
-:       a9 jun-index-poison
+:       a9 {{jun-index-pierce-poison}}
 :       20 $check-element,2
-:       a9 jun-index-wind
+:       a9 {{jun-index-pierce-wind}}
 :       20 $check-element,2
-:       a9 jun-index-pearl
+:       a9 {{jun-index-pierce-pearl}}
 :       20 $check-element,2
-:       a9 jun-index-earth
+:       a9 {{jun-index-pierce-earth}}
 :       20 $check-element,2
-:       a9 jun-index-water
+:       a9 {{jun-index-pierce-water}}
 :       20 $check-element,2
 
 :       fa
@@ -173,7 +163,7 @@ $check-prism
 :       ad a2 11
 :       89 20
 :       f0 exit-no-prism
-:       a9 jun-index-prism-wall
+:       a9 {{jun-index-prism-wall}}
 :       22 $jun-checker
 :       d0 prism-wall
 :       bb

--- a/BeyondChaos/tables/patch_junction_elemental_repel.txt
+++ b/BeyondChaos/tables/patch_junction_elemental_repel.txt
@@ -1,5 +1,5 @@
-.addr   jun-checker                     610000
-.addr   jun-check-is-damage-over-time   610920
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-is-damage-over-time   {{jun-global-check-is-damage-over-time}}
 .addr   main                            620700
 .addr   check-element                   6207a0
 .addr   check-prism                     6213c0
@@ -12,24 +12,13 @@
 # This skips forward to 022259, the end of the vanish doom patch
 .addr   return-no-reflect               02224b
 
-.def    jun-index-null-reflect  0d
-.def    jun-index-fire          40
-.def    jun-index-ice           41
-.def    jun-index-bolt          42
-.def    jun-index-poison        43
-.def    jun-index-wind          44
-.def    jun-index-pearl         45
-.def    jun-index-earth         46
-.def    jun-index-water         47
-.def    jun-index-nuke          48
-
 022235: 5c $main
 :       ea
 
 $main
 :       da
 
-:       a9 jun-index-null-reflect
+:       a9 {{jun-index-null-reflect}}
 :       22 $jun-checker
 :       d0 no-reflect
 
@@ -47,28 +36,28 @@ $main
 
 :       bb
 :       85 10
-:       a9 jun-index-fire
+:       a9 {{jun-index-repel-fire}}
 :       20 $check-element,2
 :       d0 yes-reflect
-:       a9 jun-index-ice
+:       a9 {{jun-index-repel-ice}}
 :       20 $check-element,2
 :       d0 yes-reflect
-:       a9 jun-index-bolt
+:       a9 {{jun-index-repel-bolt}}
 :       20 $check-element,2
 :       d0 yes-reflect
-:       a9 jun-index-poison
+:       a9 {{jun-index-repel-poison}}
 :       20 $check-element,2
 :       d0 yes-reflect
-:       a9 jun-index-wind
+:       a9 {{jun-index-repel-wind}}
 :       20 $check-element,2
 :       d0 yes-reflect
-:       a9 jun-index-pearl
+:       a9 {{jun-index-repel-pearl}}
 :       20 $check-element,2
 :       d0 yes-reflect
-:       a9 jun-index-earth
+:       a9 {{jun-index-repel-earth}}
 :       20 $check-element,2
 :       d0 yes-reflect
-:       a9 jun-index-water
+:       a9 {{jun-index-repel-water}}
 :       20 $check-element,2
 :       d0 yes-reflect
 
@@ -98,7 +87,7 @@ $main
 :       d0 normal-reflect-check
 :       ad a6 11
 :       f0 normal-reflect-check
-:       a9 jun-index-nuke
+:       a9 {{jun-index-repel-nuke}}
 :       22 $jun-checker
 :       f0 normal-reflect-check
 :       80 yes-reflect

--- a/BeyondChaos/tables/patch_junction_esper_defense.txt
+++ b/BeyondChaos/tables/patch_junction_esper_defense.txt
@@ -1,9 +1,7 @@
-.addr   jun-checker                     610000
-.addr   jun-mult                        610800
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-mult                        {{jun-global-mult}}
 .addr   main                            620040
 .addr   check-esper-defense             6200c0
-
-.def    jun-index           78
 
 02293d: 22 $main
 :       ea
@@ -54,7 +52,7 @@ $check-esper-defense
 :       c2 30
 :       c0 08 00
 :       b0 check-esper-defense-fail
-:       a9 jun-index 00
+:       a9 {{jun-index-esper-defense}} 00
 :       22 $jun-checker
 :       f0 check-esper-defense-fail
 :       b9 10 30

--- a/BeyondChaos/tables/patch_junction_esper_magic_proc.txt
+++ b/BeyondChaos/tables/patch_junction_esper_magic_proc.txt
@@ -1,8 +1,8 @@
-.addr   jun-checker                     610000
-.addr   jun-check-are-same-team         6105e0
-.addr   jun-mult                        610800
-.addr   jun-rng2                        610830
-.addr   jun-get-equipped-esper          610900
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-are-same-team         {{jun-global-check-are-same-team}}
+.addr   jun-mult                        {{jun-global-mult}}
+.addr   jun-rng2                        {{jun-global-rng2}}
+.addr   jun-get-equipped-esper          {{jun-global-get-equipped-esper}}
 
 .addr   main                            6201c0
 .addr       get-esper-spell                 620100
@@ -10,8 +10,6 @@
 .addr               spell-data                      046ac0
 .addr           esper-data-learn                186e00
 .addr           esper-data-spell                186e01
-
-.def    jun-index-esper-magic   01
 
 023250: 22 $main
 :       ea
@@ -35,7 +33,7 @@ $main
 :       ad 70 3a
 :       d0 main-esper-proc-exit
 .label skip-strikes-number-check
-:       a9 jun-index-esper-magic
+:       a9 {{jun-index-esper-magic}}
 :       22 $jun-checker
 :       f0 main-esper-proc-exit
 :       20 $get-esper-spell,2

--- a/BeyondChaos/tables/patch_junction_faith.txt
+++ b/BeyondChaos/tables/patch_junction_faith.txt
@@ -1,11 +1,9 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 
 .addr   main                            620bc0
 .addr   return-check-level              0222ec
 .addr   return-normal                   0222ac
 .addr   return-hit                      0222e8
-
-.def    jun-index-faith             5c
 
 0222a8: 5c $main
 
@@ -19,7 +17,7 @@ $main
 :       d0 exit-check-level
 
 :       da
-:       a9 jun-index-faith
+:       a9 {{jun-index-faith}}
 :       22 $jun-checker
 :       d0 exit-faith
 :       bb

--- a/BeyondChaos/tables/patch_junction_final_fenix.txt
+++ b/BeyondChaos/tables/patch_junction_final_fenix.txt
@@ -1,18 +1,17 @@
-.addr   jun-checker                     610000
-.addr   jun-set-target-allies           610780
-.addr   jun-queue-command               610ff0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-set-target-allies           {{jun-global-set-target-allies}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
 .addr   main                            6237a0
 .addr   return-normal                   0207a8
 .addr   return-fenix                    020798
 
-.def    jun-index                   98
 .def    phoenix-spell-index         50
-.def    final-attack-command-index  44
+.def    final-attack-command-index  {{jun-command-index-final-attack}}
 
 0207a4: 5c $main
 
 $main
-:       a9 jun-index
+:       a9 {{jun-index-final-fenix}}
 :       22 $jun-checker
 :       f0 exit-normal
 

--- a/BeyondChaos/tables/patch_junction_focus.txt
+++ b/BeyondChaos/tables/patch_junction_focus.txt
@@ -1,17 +1,11 @@
-.addr   jun-checker                     610000
-.addr   jun-check-entity-living         610600
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
 .addr   main-focus                      620800
 .addr   main-lucid-dead                 620860
 .addr   return-focus                    02095c
 .addr   check-lucid-dead                620d00
 .addr   check-focus                     620d80
 .addr   check-able-bodied               620d40
-
-.def    jun-index-focus         08
-.def    jun-index-lucid-dead    09
-.def    jun-index-commander     56
-.def    jun-index-necromancer   57
-.def    jun-index-highwind      8a
 
 020956: 5c $main-focus
 :       ea ea
@@ -46,7 +40,7 @@ $main-focus
 :       bd 18 30
 :       2c 2c 3f
 :       f0 main-focus-exit
-:       a9 jun-index-highwind
+:       a9 {{jun-index-highwind}}
 :       22 $jun-checker
 :       f0 main-focus-exit
 :       c2 20
@@ -94,7 +88,7 @@ $check-lucid-dead
 :       48
 :       86 10
 
-:       a9 jun-index-lucid-dead
+:       a9 {{jun-index-lucid-dead}}
 :       22 $jun-checker
 :       d0 exit-has-lucid-dead
 
@@ -104,7 +98,7 @@ $check-lucid-dead
 :       f0 necromancer-skip
 :       20 $check-able-bodied,2
 :       f0 necromancer-skip
-:       a9 jun-index-necromancer
+:       a9 {{jun-index-necromancer}}
 :       22 $jun-checker
 :       d0 exit-has-lucid-dead
 .label necromancer-skip
@@ -129,7 +123,7 @@ $check-focus
 :       48
 :       86 10
 
-:       a9 jun-index-focus
+:       a9 {{jun-index-focus}}
 :       22 $jun-checker
 :       d0 exit-has-focus
 
@@ -139,7 +133,7 @@ $check-focus
 :       f0 commander-skip
 :       20 $check-able-bodied,2
 :       f0 commander-skip
-:       a9 jun-index-commander
+:       a9 {{jun-index-commander}}
 :       22 $jun-checker
 :       d0 exit-has-focus
 .label commander-skip

--- a/BeyondChaos/tables/patch_junction_focus_umaro.txt
+++ b/BeyondChaos/tables/patch_junction_focus_umaro.txt
@@ -1,11 +1,8 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main-umaro                      621a40
 .addr   return-umaro                    0208c5
 .addr   return-not-umaro                02092a
 .addr   check-able-bodied               620d40
-
-.def    jun-index-focus         08
-.def    jun-index-commander     56
 
 020926: 5c $main-umaro
 
@@ -13,7 +10,7 @@ $main-umaro
 :       48 da
 :       c9 {{berserker-index:0d}}
 :       d0 exit-just-exit
-:       a9 jun-index-focus
+:       a9 {{jun-index-focus}}
 :       22 $jun-checker
 :       d0 exit-not-berserk
 .label not-focus
@@ -24,7 +21,7 @@ $main-umaro
 :       f0 commander-skip
 :       20 $check-able-bodied,2
 :       f0 commander-skip
-:       a9 jun-index-commander
+:       a9 {{jun-index-commander}}
 :       22 $jun-checker
 :       f0 commander-skip
 :       80 exit-not-berserk

--- a/BeyondChaos/tables/patch_junction_free_status_bytes.txt
+++ b/BeyondChaos/tables/patch_junction_free_status_bytes.txt
@@ -1,4 +1,4 @@
-.addr   main                    617fc0
+.addr   main                    {{jun-global-free-status-bytes-main}}
 .addr   return-normal           016a2f
 .addr   return-terminate        016a37
 

--- a/BeyondChaos/tables/patch_junction_freebie.txt
+++ b/BeyondChaos/tables/patch_junction_freebie.txt
@@ -1,10 +1,9 @@
-.addr   jun-checker                     610000
-.addr   jun-rng2                        610830
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-rng2                        {{jun-global-rng2}}
 
 .addr   main                            620f00
 
-.def    jun-index-freebie       5d
-
+.def    freebie-rate                    40
 
 0218b0: 22 $main
 :       ea
@@ -15,9 +14,9 @@ $main
 :       c9 09
 :       f0 exit-no-freebie
 :       22 $jun-rng2
-:       29 03
-:       d0 exit-no-freebie
-:       a9 jun-index-freebie
+:       c9 freebie-rate
+:       b0 exit-no-freebie
+:       a9 {{jun-index-freebie}}
 :       22 $jun-checker
 :       f0 exit-no-freebie
 :       a9 b1

--- a/BeyondChaos/tables/patch_junction_gilgam_heart.txt
+++ b/BeyondChaos/tables/patch_junction_gilgam_heart.txt
@@ -1,9 +1,7 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            620680
 .addr   return-dead                     021390
 .addr   return-alive                    02133c
-
-.def    jun-index-gilgam-heart  54
 
 02134a: 5c $main
 
@@ -13,7 +11,7 @@ $main
 
 :       da
 :       bb
-:       a9 jun-index-gilgam-heart 00
+:       a9 {{jun-index-gilgam-heart}} 00
 :       22 $jun-checker
 :       f0 still-alive
 

--- a/BeyondChaos/tables/patch_junction_gold_blood_mage.txt
+++ b/BeyondChaos/tables/patch_junction_gold_blood_mage.txt
@@ -1,4 +1,4 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   menu-load-mp                    620880
 .addr   cast-check-deduct-mp            620980
 .addr   do-mp-critical                  620b00
@@ -12,9 +12,6 @@
 .addr   return-no-junction-check-mp     0232ba
 .addr   return-enough-mp                0232e0
 .addr   return-not-enough-mp            0232c2
-
-.def    jun-index-blood         0a
-.def    jun-index-gold          0b
 
 025d39: 5c $menu-load-mp
 
@@ -33,13 +30,13 @@ $menu-load-mp
 :       5c $menu-return
 
 $cast-check-deduct-mp
-:       a9 jun-index-blood 00
+:       a9 {{jun-index-blood-mage}} 00
 :       22 $jun-checker
 :       d0 blood-mage-check-mp
 
 :       e0 08
 :       b0 is-monster-no-gold
-:       a9 jun-index-gold 00
+:       a9 {{jun-index-gold-mage}} 00
 :       22 $jun-checker
 :       d0 gold-mage-check-mp
 
@@ -77,11 +74,11 @@ $cast-check-deduct-mp
 :       5c $return-enough-mp
 
 $set-end-battle-mp
-:       a9 jun-index-blood 00
+:       a9 {{jun-index-blood-mage}} 00
 :       22 $jun-checker
 :       d0 skip-set-mp
 
-:       a9 jun-index-gold 00
+:       a9 {{jun-index-gold-mage}} 00
 :       22 $jun-checker
 :       d0 skip-set-mp
 
@@ -95,11 +92,11 @@ $load-mp-routine
 :       08
 :       c2 20
 
-:       a9 jun-index-blood 00
+:       a9 {{jun-index-blood-mage}} 00
 :       22 $jun-checker
 :       d0 blood-mage-load-mp
 
-:       a9 jun-index-gold 00
+:       a9 {{jun-index-gold-mage}} 00
 :       22 $jun-checker
 :       d0 gold-mage-load-mp
 
@@ -143,7 +140,7 @@ $gold-to-mp
 :       29 ff 00
 :       d0 max-gold
 :       ad 60 18
-:       4a 4a 4a 4a
+:       4a 4a 4a 4a 4a
 :       c9 e7 03
 :       b0 max-gold
 :       60
@@ -162,13 +159,13 @@ $do-mp-critical
 :       bb
 :       c2 20
 
-:       a9 jun-index-blood 00
+:       a9 {{jun-index-blood-mage}} 00
 :       22 $jun-checker
 :       f0 no-blood
 :       20 $deduct-blood,2
 
 .label no-blood
-:       a9 jun-index-gold 00
+:       a9 {{jun-index-gold-mage}} 00
 :       22 $jun-checker
 :       f0 no-gold
 :       20 $deduct-gold,2
@@ -198,7 +195,7 @@ $deduct-blood
 $deduct-gold
 :       ad 4c 3a
 :       48
-:       0a 0a 0a 0a
+:       0a 0a 0a 0a 0a
 :       8d 4c 3a
 :       ad 60 18
 :       38

--- a/BeyondChaos/tables/patch_junction_highwind.txt
+++ b/BeyondChaos/tables/patch_junction_highwind.txt
@@ -1,6 +1,6 @@
-.addr   jun-checker                     610000
-.addr   jun-mult                        610800
-.addr   jun-reload-character-commands   610f80
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-mult                        {{jun-global-mult}}
+.addr   jun-reload-character-commands   {{jun-global-reload-character-commands}}
 .addr   main-set-flag                   621f00
 .addr   main-clear-flag                 621f20
 .addr   set-menu-jump                   621f40
@@ -12,8 +12,6 @@
 .addr   return-hang                     0200e3
 .addr   return-highwind-menu-normal     014849
 .addr   return-highwind-menu-highwind   014855
-
-.def    jun-index-highwind      8a
 
 020144: 22 $main-clear-flag
 :       ea ea
@@ -31,7 +29,7 @@
 :       ea ea
 
 $main-set-flag
-:       a9 jun-index-highwind 00
+:       a9 {{jun-index-highwind}} 00
 :       22 $jun-checker
 :       d0 main-set-highwind
 :       bd 18 30
@@ -44,7 +42,7 @@ $main-set-flag
 :       6b
 
 $main-clear-flag
-:       a9 jun-index-highwind 00
+:       a9 {{jun-index-highwind}} 00
 :       22 $jun-checker
 :       d0 main-clear-highwind
 :       bd 18 30
@@ -57,7 +55,7 @@ $main-clear-flag
 :       6b
 
 $main-jump-command
-:       a9 jun-index-highwind
+:       a9 {{jun-index-highwind}}
 :       22 $jun-checker
 :       f0 exit-land
 :       bd 18 30
@@ -79,7 +77,7 @@ $main-jump-command
 :       5c $return-land
 
 $main-palidor
-:       a9 jun-index-highwind
+:       a9 {{jun-index-highwind}}
 :       22 $jun-checker
 :       f0 exit-palidor
 :       bd 4d 3e
@@ -131,7 +129,7 @@ $main-sky-die
 :       bd 18 30
 :       2c 2c 3f
 :       f0 exit-sky-die-normal
-:       a9 jun-index-highwind 00
+:       a9 {{jun-index-highwind}} 00
 :       22 $jun-checker
 :       d0 exit-sky-die-death
 :       bd 18 30

--- a/BeyondChaos/tables/patch_junction_hit_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_hit_trigger.txt
@@ -1,23 +1,24 @@
-.addr   jun-checker                     610000
-.addr   jun-deduct-item-if-possible     610740
-.addr   jun-rng1                        610820
-.addr   jun-queue-command               610ff0
-.addr   jun-check-is-damage-over-time   610920
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-entity-can-act        {{jun-global-check-entity-can-act}}
+.addr   jun-deduct-item-if-possible     {{jun-global-deduct-item-if-possible}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
+.addr   jun-check-is-damage-over-time   {{jun-global-check-is-damage-over-time}}
 .addr   main                            622400
-.addr   null-secondary-data             6224e0
+.addr   null-secondary-data             6227e0
+.addr   do-quickening-penalty           622780
 
 .addr   living-characters               7e3a74
+.addr   current-level-address           7e3b18
+.addr   current-current-hp-address      7e3bf4
+.addr   current-current-mp-address      7e3c08
+.addr   current-max-hp-address          7e3c1c
+.addr   current-max-mp-address          7e3c30
 
-.def    jun-index-add-steal     2f
-.def    jun-index-astral        7d
-.def    jun-index-vorpal        7e
-.def    jun-index-vampire       8f
-.def    jun-index-quickening    94
-.def    jun-index-gunblade      95
-
-.def    super-ball-item-index   fa
-.def    hyperdrive-index        d1
-.def    custom-mp-command-index 42
+.def    super-ball-item-index       fa
+.def    hyperdrive-index            d1
+.def    custom-mp-command-index     {{jun-command-index-custom-mp-spell}}
+.def    fixed-damage-command-index  {{jun-command-index-fixed-damage}}
 
 021771: 22 $null-secondary-data
 
@@ -34,8 +35,8 @@ $main
 :       ad a9 11
 :       d0 no-add-steal
 :       22 $jun-rng1
-:       90 no-add-steal
-:       a9 jun-index-add-steal
+:       b0 no-add-steal
+:       a9 {{jun-index-add-steal}}
 :       22 $jun-checker
 :       f0 no-add-steal
 :       a9 a4
@@ -45,7 +46,7 @@ $main
 :       a9 01
 :       2c a2 11
 :       f0 not-physical
-:       a9 jun-index-vorpal
+:       a9 {{jun-index-vorpal}}
 :       22 $jun-checker
 :       f0 no-vorpal
 :       a9 20
@@ -54,7 +55,7 @@ $main
 .label no-vorpal
 :       a5 b5
 :       d0 no-gunblade
-:       a9 jun-index-gunblade
+:       a9 {{jun-index-gunblade}}
 :       22 $jun-checker
 :       f0 no-gunblade
 :       a9 super-ball-item-index
@@ -75,13 +76,19 @@ $main
 .label not-physical
 :       ad a5 11
 :       f0 no-quickening
+:       ad 4c 3a
+:       f0 no-quickening
 :       a5 b7
 :       1a
 :       d0 no-quickening
-:       a9 jun-index-quickening
-:       22 $jun-checker
+:       22 $jun-check-entity-can-act
 :       f0 no-quickening
 :       c2 20
+:       bd $current-current-hp-address,2
+:       f0 no-quickening
+:       a9 {{jun-index-quickening}} 00
+:       22 $jun-checker
+:       f0 no-quickening
 :       a5 b8
 :       2c $living-characters,2
 :       e2 20
@@ -90,6 +97,7 @@ $main
 :       4a
 :       6d 4c 3a
 :       90 quickening-no-overflow
+:       20 $do-quickening-penalty,2
 :       a9 ff
 .label quickening-no-overflow
 :       cd a5 11
@@ -104,6 +112,7 @@ $main
 :       b0 no-quickening
 :       1a
 :       85 b7
+:       20 @quickening-add-hp-damage,2
 :       a9 custom-mp-command-index
 :       8d 7a 3a
 :       a5 b6
@@ -111,7 +120,8 @@ $main
 :       22 $jun-queue-command
 
 .label no-quickening
-:       a9 jun-index-astral
+:       e2 20
+:       a9 {{jun-index-astral}}
 :       22 $jun-checker
 :       f0 no-astral
 :       a9 80
@@ -121,7 +131,7 @@ $main
 :       a9 01
 :       2c a4 11
 :       d0 no-vampire
-:       a9 jun-index-vampire
+:       a9 {{jun-index-vampire}}
 :       22 $jun-checker
 :       f0 no-vampire
 :       a9 02
@@ -134,6 +144,55 @@ $main
 :       a9 20
 :       14 b2
 :       6b
+
+$do-quickening-penalty
+:       5a
+
+:       c2 20
+:       bd $current-max-hp-address,2
+:       20 @reduce-three-quarters,2
+:       9d $current-max-hp-address,2
+:       bd $current-current-hp-address,2
+:       20 @reduce-three-quarters,2
+:       9d $current-current-hp-address,2
+:       bd $current-max-mp-address,2
+:       20 @reduce-three-quarters,2
+:       9d $current-max-mp-address,2
+:       bd $current-current-mp-address,2
+:       20 @reduce-three-quarters,2
+:       9d $current-current-mp-address,2
+:       a9 00 00
+:       e2 20
+:       bd $current-level-address,2
+:       20 @reduce-three-quarters,2
+:       9d $current-level-address,2
+:       7a
+:       60
+
+.label reduce-three-quarters
+:       1a 4a
+:       48
+:       4a
+:       18
+:       63 01
+:       83 01
+:       68
+:       60
+
+.label quickening-add-hp-damage
+:       a9 fixed-damage-command-index
+:       8d 7a 3a
+:       c2 20
+:       a5 b8
+:       48
+:       a5 b7
+:       29 ff 00
+:       85 b8
+:       22 $jun-queue-command
+:       68
+:       85 b8
+:       e2 20
+:       60
 
 $null-secondary-data
 :       a5 b5

--- a/BeyondChaos/tables/patch_junction_initiative.txt
+++ b/BeyondChaos/tables/patch_junction_initiative.txt
@@ -1,16 +1,14 @@
-.addr   jun-checker                     610000
-.addr   jun-check-are-same-team         6105e0
-.addr   jun-check-entity-living         610600
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-are-same-team         {{jun-global-check-are-same-team}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
 .addr   main                            621600
 .addr   check-esper-defense             6200c0
 .addr   return-loop                     022594
 .addr   return-terminate                022600
 
-.def    jun-index-initiative    04
-.def    jun-index-regenerator   51
-.def    jun-index-auto-reraise  75
-.def    jun-index-final-fenix   98
-.def    jun-index-plague        a4
+.addr   do-juggernaut-burst             622900
+
+.addr   current-level-address           7e3b18
 
 0225fa: 5c $main
 :       ea ea
@@ -18,7 +16,9 @@
 $main
 :       bb
 
-:       a9 jun-index-regenerator
+:       20 $do-juggernaut-burst,2
+
+:       a9 {{jun-index-regenerator}}
 :       22 $jun-checker
 :       f0 no-regenerator
 :       bd e8 3d
@@ -28,10 +28,10 @@ $main
 .label no-regenerator
 :       22 $jun-check-entity-living
 :       f0 no-auto-reraise
-:       a9 jun-index-final-fenix
+:       a9 {{jun-index-final-fenix}}
 :       22 $jun-checker
 :       d0 yes-auto-reraise
-:       a9 jun-index-auto-reraise
+:       a9 {{jun-index-auto-reraise}}
 :       22 $jun-checker
 :       f0 no-auto-reraise
 .label yes-auto-reraise
@@ -61,14 +61,14 @@ $main
 
 .label no-esper-defense
 :       e2 30
-:       a9 jun-index-plague
+:       a9 {{jun-index-plague}}
 :       22 $jun-checker
 :       f0 no-plague
 :       20 @do-plague,2
 
 .label no-plague
 :       fa
-:       a9 jun-index-initiative
+:       a9 {{jun-index-initiative}}
 :       22 $jun-checker
 :       f0 main-exit
 :       a9 ff
@@ -97,6 +97,29 @@ $main
 :       88 88
 :       10 plague-loop
 :       7a
+:       60
+
+$do-juggernaut-burst
+:       a9 {{jun-index-juggernaut}}
+:       22 $jun-checker
+:       f0 no-juggernaut
+:       bd $current-level-address,2
+:       1a
+:       4a
+:       9d $current-level-address,2
+
+.label no-juggernaut
+:       a9 {{jun-index-burst}}
+:       22 $jun-checker
+:       f0 no-burst
+:       bd $current-level-address,2
+:       1a
+:       4a
+:       18
+:       7d $current-level-address,2
+:       9d $current-level-address,2
+
+.label no-burst
 :       60
 
 VALIDATION

--- a/BeyondChaos/tables/patch_junction_innate_runic.txt
+++ b/BeyondChaos/tables/patch_junction_innate_runic.txt
@@ -1,17 +1,14 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            6205c0
 .addr   return-normal                   023543
 .addr   return-runic                    023545
-
-.def    jun-index-runic         59
-
 
 02353e: 5c $main
 
 $main
 :       da
 :       bb
-:       a9 jun-index-runic
+:       a9 {{jun-index-innate-runic}}
 :       22 $jun-checker
 :       f0 no-junction
 

--- a/BeyondChaos/tables/patch_junction_instant_act.txt
+++ b/BeyondChaos/tables/patch_junction_instant_act.txt
@@ -1,8 +1,5 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            620400
-
-.def    jun-index-instant-act   06
-.def    jun-index-highwind      8a
 
 0203f5: 22 $main
 :       ea
@@ -11,11 +8,11 @@ $main
 :       48
 :       c9 16
 :       d0 no-highwind
-:       a9 jun-index-highwind
+:       a9 {{jun-index-highwind}}
 :       22 $jun-checker
 :       d0 exit-no-delay
 .label no-highwind
-:       a9 jun-index-instant-act
+:       a9 {{jun-index-instant-act}}
 :       22 $jun-checker
 :       d0 exit-no-delay
 .label exit-normal-delay

--- a/BeyondChaos/tables/patch_junction_instant_run.txt
+++ b/BeyondChaos/tables/patch_junction_instant_run.txt
@@ -1,10 +1,8 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            620430
 .addr   check-runner                    620460
 .addr   return-found-runners            025be2
 .addr   return-found-no-runners         025be0
-
-.def    jun-index           05
 
 025bdb: 5c $main
 
@@ -37,7 +35,7 @@ $check-runner
 :       bd a0 3a
 :       4a
 :       90 check-runner-exit
-:       a9 jun-index
+:       a9 {{jun-index-instant-run}}
 :       22 $jun-checker
 :       f0 check-runner-exit
 :       bd 18 30

--- a/BeyondChaos/tables/patch_junction_leech.txt
+++ b/BeyondChaos/tables/patch_junction_leech.txt
@@ -1,15 +1,13 @@
-.addr   jun-checker                     610000
-.addr   jun-check-are-same-team         6105e0
-.addr   jun-check-entity-living         610600
-.addr   jun-check-is-damage-over-time   610920
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-are-same-team         {{jun-global-check-are-same-team}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-check-is-damage-over-time   {{jun-global-check-is-damage-over-time}}
 .addr   main                            622500
 .addr   main-damage                     622540
 .addr   return-normal                   020c9c
 .addr   check-has-leech                 622580
 
 .addr   living-characters               7e3a74
-
-.def    jun-index           36
 
 025b74: 22 $main
 :       ea ea
@@ -82,7 +80,7 @@ $check-has-leech
 
 :       22 $jun-check-entity-living
 :       f0 has-leech-fail
-:       a9 jun-index
+:       a9 {{jun-index-leech}}
 :       22 $jun-checker
 :       f0 has-leech-fail
 

--- a/BeyondChaos/tables/patch_junction_maintenance.txt
+++ b/BeyondChaos/tables/patch_junction_maintenance.txt
@@ -1,14 +1,12 @@
-.addr   jun-checker                     610000
-.addr   jun-rng2                        610830
-.addr   jun-rng3                        610840
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-rng2                        {{jun-global-rng2}}
+.addr   jun-rng3                        {{jun-global-rng3}}
 
 .addr   main-enemy-steal                621c00
 .addr   main-ogre-nix                   621c20
 
 .addr   old-rng2                        024b5a
 .addr   old-rng3                        024b65
-
-.def    jun-index       9d
 
 023a0c: 22 $main-enemy-steal
 :       ea ea
@@ -19,7 +17,7 @@ $main-enemy-steal
 :       da
 :       bb
 :       ee 01 34
-:       a9 jun-index
+:       a9 {{jun-index-maintenance}}
 :       22 $jun-checker
 :       f0 steal-no-maintenance
 :       a9 ff
@@ -32,7 +30,7 @@ $main-enemy-steal
 
 $main-ogre-nix
 :       bb
-:       a9 jun-index
+:       a9 {{jun-index-maintenance}}
 :       22 $jun-checker
 :       f0 ogre-nix-no-maintenance
 :       a9 00

--- a/BeyondChaos/tables/patch_junction_miasma.txt
+++ b/BeyondChaos/tables/patch_junction_miasma.txt
@@ -1,16 +1,27 @@
-.addr   jun-checker                     610000
-.addr   jun-check-entity-living         610600
-.addr   jun-rng1                        610820
-.addr   jun-rng2                        610830
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-rng2                        {{jun-global-rng2}}
+.addr   jun-rng2-noluck                 {{jun-global-rng2-noluck}}
+.addr   jun-rng3                        {{jun-global-rng3}}
 .addr   main                            620b40
+.addr   main-level-modulation           622860
 
-.def    jun-index-miasma        50
-.def    jun-index-regenerator   51
+.addr   monster-indexes                 7e1ff9
+.addr   character-info                  7e3010
+.addr   current-level-address           7e3b18
+.addr   character-base-level-address    7e1608
+.addr   monster-base-level-address      0f0010
+
+.def    miasma-success-rate             40
+.def    level-modulation-rate           80
 
 025ad6: 22 $main
 
 $main
 :       9b
+:       20 $main-level-modulation,2
+
 :       bd e4 3e
 :       29 04
 :       f0 not-poisoned
@@ -21,9 +32,9 @@ $main
 :       22 $jun-check-entity-living
 :       f0 miasma-fail-rng
 :       22 $jun-rng2
-:       29 03
-:       d0 miasma-fail-rng
-:       a9 jun-index-miasma
+:       c9 miasma-success-rate
+:       b0 miasma-fail-rng
+:       a9 {{jun-index-miasma}}
 :       22 $jun-checker
 :       d0 trigger-miasma
 .label miasma-fail-rng
@@ -35,8 +46,8 @@ $main
 :       29 02
 :       f0 no-junction
 :       22 $jun-rng1
-:       90 no-junction
-:       a9 jun-index-regenerator
+:       b0 no-junction
+:       a9 {{jun-index-regenerator}}
 :       22 $jun-checker
 :       d0 trigger-regen
 
@@ -54,6 +65,85 @@ $main
 :       bb
 :       a9 00
 :       6b
+
+$main-level-modulation
+:       20 @get-base-level,2
+:       48
+:       22 $jun-rng2-noluck
+:       c9 level-modulation-rate
+:       b0 no-burst
+
+:       a9 {{jun-index-juggernaut}}
+:       22 $jun-checker
+:       f0 no-juggernaut
+:       20 @do-juggernaut,2
+
+.label no-juggernaut
+:       a9 {{jun-index-burst}}
+:       22 $jun-checker
+:       f0 no-burst
+:       20 @do-burst,2
+
+.label no-burst
+:       68
+:       60
+
+.label get-base-level
+:       08
+:       c2 30
+:       da
+:       e0 08 00
+:       b0 get-base-level-monster
+:       bd $character-info,2
+:       aa
+:       bf $character-base-level-address
+:       80 get-base-level-exit
+.label get-base-level-monster
+:       bd $monster-indexes,2
+:       0a 0a 0a 0a 0a
+:       aa
+:       bf $monster-base-level-address
+.label get-base-level-exit
+:       29 ff 00
+:       fa 28
+:       60
+
+.label do-juggernaut
+:       bd $current-level-address,2
+:       c3 03
+:       90 do-juggernaut-levelup
+:       e3 03
+:       1a
+:       22 $jun-rng3
+:       c9 00
+:       d0 do-juggernaut-exit
+.label do-juggernaut-levelup
+:       bd $current-level-address,2
+:       1a
+:       c9 64
+:       b0 do-juggernaut-exit
+:       9d $current-level-address,2
+.label do-juggernaut-exit
+:       60
+
+.label do-burst
+:       bd $current-level-address,2
+:       c3 03
+:       b0 do-burst-leveldown
+:       e3 03
+:       49 ff
+:       1a 1a
+:       22 $jun-rng3
+:       c9 00
+:       d0 do-burst-exit
+.label do-burst-leveldown
+:       bd $current-level-address,2
+:       3a
+:       f0 do-burst-exit
+:       30 do-burst-exit
+:       9d $current-level-address,2
+.label do-burst-exit
+:       60
 
 VALIDATION
 025ad6: bd f0 3a

--- a/BeyondChaos/tables/patch_junction_mp_regen.txt
+++ b/BeyondChaos/tables/patch_junction_mp_regen.txt
@@ -1,7 +1,5 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            621500
-
-.def    jun-index           7c
 
 025056: 22 $main
 :       ea
@@ -11,7 +9,7 @@ $main
 :       bb
 :       ad a1 11
 :       d0 normal-regen
-:       a9 jun-index
+:       a9 {{jun-index-mp-regen}}
 :       22 $jun-checker
 :       d0 mp-regen
 

--- a/BeyondChaos/tables/patch_junction_mp_switch.txt
+++ b/BeyondChaos/tables/patch_junction_mp_switch.txt
@@ -1,52 +1,81 @@
-.addr   jun-checker                     610000
-.addr   jun-rng1                        610820
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
 .addr   main                            621480
 .addr   return-no-damage                02133b
 .addr   return-healing                  02132a
 .addr   return-damage                   02133d
 .addr   return-mp-damage                02136b
 
-.def    jun-index-mp-switch     7b
-.def    jun-index-blood         0a
-.def    jun-index-gold          0b
+.addr   current-hp-address              7e3bf4
+.addr   current-mp-address              7e3c08
 
-021326: 5c $main
+.def    fixed-damage-command-index      {{jun-command-index-fixed-damage}}
+
+0212f7: 22 $main
+:       ea
+:       ea ea
+:       ea ea
 
 $main
-:       f0 exit-no-damage
-:       b0 exit-healing
-:       48 da
-:       b9 08 3c
-:       f0 exit-damage
+# 16-bit A
+# target in Y
+:       a2 02
+:       ad a2 11
+:       30 exit-normal-concerns-mp
+:       b9 $current-mp-address,2
+:       f0 exit-normal
+:       b9 d0 33
+:       f0 exit-normal
+:       1a
+:       f0 exit-normal
+:       3a
+:       d9 $current-hp-address,2
+:       b0 exit-normal
 :       22 $jun-rng1
-:       90 exit-damage
+:       b0 exit-normal
+
+:       a9 {{jun-index-mp-switch}} 00
+:       22 $jun-checker
+:       f0 exit-normal
+:       a9 {{jun-index-blood-mage}} 00
+:       22 $jun-checker
+:       d0 exit-normal
+:       a9 {{jun-index-gold-mage}} 00
+:       22 $jun-checker
+:       d0 exit-normal
+
+:       da
 :       bb
+:       ad 7a 3a
+:       48
+:       a5 b8
+:       48
+:       b9 d0 33
+:       09 00 40
+:       85 b8
+:       a9 fixed-damage-command-index 00
+:       8d 7a 3a
+:       22 $jun-queue-command
 
-:       a9 jun-index-mp-switch 00
-:       22 $jun-checker
-:       f0 exit-damage
+:       68
+:       85 b8
+:       68
+:       8d 7a 3a
+:       fa
 
-:       a9 jun-index-blood 00
-:       22 $jun-checker
-:       d0 exit-damage
+:       a9 ff ff
+:       99 d0 33
 
-:       a9 jun-index-gold 00
-:       22 $jun-checker
-:       d0 exit-damage
-
-:       fa 68
-:       18
-:       5c $return-mp-damage
-.label exit-no-damage
-:       5c $return-no-damage
-.label exit-healing
-:       5c $return-healing
-.label exit-damage
-:       fa 68
-:       18
-:       5c $return-damage
+:       6b
+.label exit-normal
+:       a2 00
+.label exit-normal-concerns-mp
+:       6b
 
 VALIDATION
 
-021326: f0 13
-:       90 13
+0212f7: a2 02
+:       ad a2 11
+:       30 02
+:       a2 00

--- a/BeyondChaos/tables/patch_junction_poach.txt
+++ b/BeyondChaos/tables/patch_junction_poach.txt
@@ -1,6 +1,5 @@
-.addr   jun-checker                     610000
-.addr   jun-rng1                        610820
-.addr   jun-rng2                        610830
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-rng2                        {{jun-global-rng2}}
 .addr   main                            620a40
 .addr   get-steal-or-drop               620ab0
 .addr   obtain-item                     620ad0
@@ -10,8 +9,7 @@
 .addr   monster-drops                   0f3002
 .addr   jump-set-death                  020e32
 
-.def    jun-index-poach         0e
-.def    jun-index-imp-harvest   0f
+.def    poach-rare-rate                 20
 
 0213a1: 5c $main
 :       ea ea
@@ -43,12 +41,12 @@ $main
 :       89 20 00
 :       f0 check-poach
 
-:       a9 jun-index-imp-harvest 00
+:       a9 {{jun-index-imp-harvest}} 00
 :       22 $jun-checker
 :       d0 imp-harvest
 
 .label check-poach
-:       a9 jun-index-poach 00
+:       a9 {{jun-index-poach}} 00
 :       22 $jun-checker
 :       d0 poach
 
@@ -70,8 +68,9 @@ $main
 # choose rare item 1/8 of the time
 :       aa
 :       22 $jun-rng2
-:       29 07 00
-:       f0 poach-choose-rare
+:       29 ff 00
+:       c9 poach-rare-rate 00
+:       90 poach-choose-rare
 :       8a
 :       eb
 :       80 poach-item-chosen
@@ -85,7 +84,8 @@ $get-steal-or-drop
 :       b9 $monster-indexes,2
 :       0a 0a
 :       aa
-:       22 $jun-rng1
+:       22 $jun-rng2
+:       4a
 :       b0 choose-drop
 :       bf $monster-steals
 :       60

--- a/BeyondChaos/tables/patch_junction_potent_venom.txt
+++ b/BeyondChaos/tables/patch_junction_potent_venom.txt
@@ -1,11 +1,10 @@
-.addr   jun-checker                     610000
-.addr   jun-rng1                        610820
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-rng1                        {{jun-global-rng1}}
 
 .addr   main                            6211a0
 .addr   return-normal                   02445c
 .addr   return-poisoned                 02447d
 
-.def    jun-index-potent-venom  58
 .def    poison-bit              04 00
 
 024456: 5c $main
@@ -40,7 +39,7 @@ $main
 :       89 poison-bit
 :       d0 exit-normal
 
-:       a9 jun-index-potent-venom 00
+:       a9 {{jun-index-potent-venom}} 00
 :       22 $jun-checker
 :       f0 exit-normal
 

--- a/BeyondChaos/tables/patch_junction_prehit_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_prehit_trigger.txt
@@ -1,18 +1,18 @@
-.addr   jun-checker                     610000
-.addr   jun-checker-y                   6100a0
-.addr   jun-check-are-same-team         6105e0
-.addr   jun-check-entity-living         610600
-.addr   jun-check-entity-can-act        6106c0
-.addr   jun-set-target-allies           610780
-.addr   jun-mult                        610800
-.addr   jun-rng1                        610820
-.addr   jun-rng2                        610830
-.addr   jun-divide                      610860
-.addr   jun-check-is-damage-over-time   610920
-.addr   jun-check-spell-targets-ally    610960
-.addr   jun-generic-dispatch            610f00
-.addr   jun-queue-self-spell            610fc0
-.addr   jun-queue-command               610ff0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-checker-y                   {{jun-global-checker-y}}
+.addr   jun-check-are-same-team         {{jun-global-check-are-same-team}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-check-entity-can-act        {{jun-global-check-entity-can-act}}
+.addr   jun-set-target-allies           {{jun-global-set-target-allies}}
+.addr   jun-mult                        {{jun-global-mult}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-rng2                        {{jun-global-rng2}}
+.addr   jun-divide                      {{jun-global-divide}}
+.addr   jun-check-is-damage-over-time   {{jun-global-check-is-damage-over-time}}
+.addr   jun-check-spell-targets-ally    {{jun-global-check-spell-targets-ally}}
+.addr   jun-generic-dispatch            {{jun-global-generic-dispatch}}
+.addr   jun-queue-self-spell            {{jun-global-queue-self-spell}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
 
 .addr   get-esper-spell                 620100
 
@@ -30,27 +30,15 @@
 .addr   return-normal                   022215
 .addr   return-miss                     0222d1
 
-.def    jun-index-null-freeze       5a
-.def    jun-index-firestarter       74
-.def    jun-index-null-sleep        a6
-
-.def    jun-index-counter-all       84
-.def    jun-index-hamedo            85
-.def    jun-index-return-magic      86
-.def    jun-index-esper-counter     87
-.def    jun-index-resonate          8d
-.def    jun-index-sunken-state      8e
-.def    jun-index-decisive          9c
-.def    jun-index-gaia-assist       a1
-.def    jun-index-flinch            a2
-.def    jun-index-discordant        a5
-
 .def    vanish-spell-index          26
-.def    spell-proc-command-index    43
-.def    final-attack-command-index  44
+.def    spell-proc-command-index    {{jun-command-index-spell-proc}}
+.def    final-attack-command-index  {{jun-command-index-final-attack}}
 
 .def    rippler-allowed-statuses1   37 fd
 .def    rippler-allowed-statuses2   fe 84
+
+.def    flinch-rate                 40
+.def    gaia-assist-rate            40
 
 022211: 5c $main
 
@@ -74,7 +62,7 @@ $main
 :       b9 f9 3e
 :       29 02
 :       f0 no-freeze
-:       a9 jun-index-null-freeze
+:       a9 {{jun-index-null-freeze}}
 :       22 $jun-checker-y
 :       d0 freeze-exit-miss
 
@@ -84,14 +72,14 @@ $main
 :       f0 no-sleep
 :       b9 f9 3c
 :       f0 no-sleep
-:       a9 jun-index-null-sleep
+:       a9 {{jun-index-null-sleep}}
 :       22 $jun-checker-y
 :       d0 freeze-exit-miss
 
 .label no-sleep
 :       fa
 
-:       a9 jun-index-resonate
+:       a9 {{jun-index-resonate}}
 :       22 $jun-checker
 :       d0 resonate
 :       22 $jun-checker-y
@@ -102,7 +90,7 @@ $main
 :       e2 20
 
 .label no-resonate
-:       a9 jun-index-decisive
+:       a9 {{jun-index-decisive}}
 :       22 $jun-checker
 :       f0 no-decisive
 :       9c 1a 34
@@ -137,7 +125,7 @@ $main-firestarter
 :       25 b8
 :       e2 20
 :       f0 firestarter-skip
-:       a9 jun-index-firestarter
+:       a9 {{jun-index-firestarter}}
 :       22 $jun-checker
 :       f0 firestarter-skip
 :       a9 02
@@ -177,8 +165,8 @@ $main-counter
 :       d0 no-counter-all
 
 :       22 $jun-rng1
-:       90 no-flinch
-:       a9 jun-index-flinch
+:       b0 no-flinch
+:       a9 {{jun-index-flinch}}
 :       22 $jun-checker
 :       f0 no-flinch
 :       b9 19 32
@@ -188,15 +176,15 @@ $main-counter
 
 .label no-flinch
 :       22 $jun-rng2
-:       29 03
-:       d0 no-counter-all
-:       a9 jun-index-counter-all
+:       c9 flinch-rate
+:       b0 no-counter-all
+:       a9 {{jun-index-counter-all}}
 :       22 $jun-checker-y
 :       f0 no-counter-all
 :       20 $queue-counter,2
 
 .label no-counter-all
-:       a9 jun-index-discordant
+:       a9 {{jun-index-discordant}}
 :       22 $jun-checker
 :       f0 no-discordant
 :       20 $do-discordant,2
@@ -210,7 +198,7 @@ $main-counter
 :       d9 08 3c
 :       b0 no-return-magic
 .label monsters-ignore-mp
-:       a9 jun-index-return-magic
+:       a9 {{jun-index-return-magic}}
 :       22 $jun-checker-y
 :       f0 no-return-magic
 :       c2 20
@@ -239,7 +227,7 @@ $main-counter
 :       89 10
 :       d0 no-sunken-state
 
-:       a9 jun-index-sunken-state
+:       a9 {{jun-index-sunken-state}}
 :       22 $jun-checker-y
 :       f0 no-sunken-state
 :       da
@@ -252,8 +240,8 @@ $main-counter
 :       a5 b5
 :       d0 no-hamedo
 :       22 $jun-rng1
-:       90 no-hamedo
-:       a9 jun-index-hamedo
+:       b0 no-hamedo
+:       a9 {{jun-index-hamedo}}
 :       22 $jun-checker-y
 :       f0 no-hamedo
 :       20 $queue-counter,2
@@ -329,7 +317,7 @@ $main-resonate
 :       60
 
 $main-esper-counter
-:       a9 jun-index-esper-counter
+:       a9 {{jun-index-esper-counter}}
 :       22 $jun-checker-y
 :       f0 no-esper-counter
 :       c2 20
@@ -368,14 +356,14 @@ $main-gaia
 :       f0 no-gaia-defender
 :       22 $jun-check-is-damage-over-time
 :       d0 no-gaia-defender
-:       a9 jun-index-gaia-assist
+:       a9 {{jun-index-gaia-assist}}
 :       22 $jun-checker
 :       f0 no-gaia-attacker
 :       20 @do-gaia,2
 
 .label no-gaia-attacker
 :       8a bb a8
-:       a9 jun-index-gaia-assist
+:       a9 {{jun-index-gaia-assist}}
 :       22 $jun-checker
 :       f0 no-gaia-defender
 :       20 @do-gaia,2
@@ -388,8 +376,8 @@ $main-gaia
 :       b9 e1 32
 :       48
 :       22 $jun-rng2
-:       29 03
-:       d0 do-gaia-exit
+:       c9 gaia-assist-rate
+:       b0 do-gaia-exit
 :       da
 :       ae e2 11
 :       bf $background-dances-address

--- a/BeyondChaos/tables/patch_junction_ravenous.txt
+++ b/BeyondChaos/tables/patch_junction_ravenous.txt
@@ -1,9 +1,7 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            6221a0
 .addr   return-normal                   020e07
 .addr   return-ravenous                 020e1d
-
-.def    jun-index-ravenous          72
 
 020e02: 5c $main
 
@@ -15,7 +13,7 @@ $main
 :       30 using_hp
 :       aa
 .label using_hp
-:       a9 jun-index-ravenous 00
+:       a9 {{jun-index-ravenous}} 00
 :       22 $jun-checker
 :       f0 exit-normal
 :       fa

--- a/BeyondChaos/tables/patch_junction_reflect_boost.txt
+++ b/BeyondChaos/tables/patch_junction_reflect_boost.txt
@@ -1,30 +1,50 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-checker-y                   {{jun-global-checker-y}}
+.addr   jun-compare-x-y                 {{jun-global-compare-x-y}}
+.addr   boost-damage-quarter            621440
 .addr   main                            620a00
-
-.def    jun-index               0c
 
 0234bb: 22 $main
 :       ea
 
 $main
+:       a3 06
+:       aa
 :       c2 20
-:       9b
-:       a6 ee
-:       a9 jun-index 00
-:       22 $jun-checker
-:       d0 has-reflect-boost
+:       a9 00 00
+:       48
+:       a0 12
+.label loop
+:       b9 18 30
+:       23 06
+:       d0 test-for-boost
+:       22 $jun-compare-x-y
+:       f0 test-for-boost
+:       80 skip
+.label test-for-boost
+:       a9 {{jun-index-reflect-boost}} 00
+:       22 $jun-checker-y
+:       f0 skip
+
+:       a3 01
+:       1a
+:       83 01
+
+.label skip
+:       88 88
+:       10 loop
+
+:       68
+:       d0 boost-reflect
 :       4e b0 11
-:       bb
 :       6b
-.label has-reflect-boost
-:       ad b0 11
-:       4a
-:       6d b0 11
-:       90 no-overflow
-:       a9 ff ff
-.label no-overflow
-:       8d b0 11
-:       bb
+
+.label boost-reflect
+:       3a
+:       f0 exit
+:       20 $boost-damage-quarter,2
+:       80 boost-reflect
+.label exit
 :       6b
 
 VALIDATION

--- a/BeyondChaos/tables/patch_junction_status_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_status_trigger.txt
@@ -1,12 +1,12 @@
-.addr   jun-checker                     610000
-.addr   jun-check-entity-living         610600
-.addr   jun-check-entity-can-act        6106c0
-.addr   jun-check-are-same-team         6105e0
-.addr   jun-deduct-item-if-possible     610740
-.addr   jun-mult                        610800
-.addr   jun-rng1                        610820
-.addr   jun-count-bits                  6108c0
-.addr   jun-queue-command               610ff0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-check-entity-can-act        {{jun-global-check-entity-can-act}}
+.addr   jun-check-are-same-team         {{jun-global-check-are-same-team}}
+.addr   jun-deduct-item-if-possible     {{jun-global-deduct-item-if-possible}}
+.addr   jun-mult                        {{jun-global-mult}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-count-bits                  {{jun-global-count-bits}}
+.addr   jun-queue-command               {{jun-global-queue-command}}
 .addr   main                            622080
 .addr   main-auto-item                  6222c0
 .addr   use-best-item                   622200
@@ -16,9 +16,6 @@
 .addr       item-properties-status-byte     185015
 .addr   do-auto-item                    622280
 
-.def    jun-index-auto-down         81
-.def    jun-index-auto-revivify     82
-.def    jun-index-auto-remedy       83
 .def    wound-status                80 00
 .def    zombie-status               02 00
 .def    remedy-status               65 48
@@ -31,7 +28,7 @@ $main
 :       c0 08
 :       90 main-is-human
 :       22 $jun-rng1
-:       90 exit-main
+:       b0 exit-main
 .label main-is-human
 :       20 $main-auto-item,2
 
@@ -50,7 +47,7 @@ $main-auto-item
 :       29 wound-status
 :       f0 no-fenix
 :       83 01
-:       a9 jun-index-auto-down 00
+:       a9 {{jun-index-auto-down}} 00
 :       20 $do-auto-item,2
 
 .label no-fenix
@@ -58,7 +55,7 @@ $main-auto-item
 :       29 zombie-status
 :       f0 no-revivify
 :       83 01
-:       a9 jun-index-auto-revivify 00
+:       a9 {{jun-index-auto-revivify}} 00
 :       20 $do-auto-item,2
 
 .label no-revivify
@@ -66,7 +63,7 @@ $main-auto-item
 :       29 remedy-status
 :       f0 no-remedy
 :       83 01
-:       a9 jun-index-auto-remedy 00
+:       a9 {{jun-index-auto-remedy}} 00
 :       20 $do-auto-item,2
 
 .label no-remedy

--- a/BeyondChaos/tables/patch_junction_taunt_salve.txt
+++ b/BeyondChaos/tables/patch_junction_taunt_salve.txt
@@ -1,13 +1,15 @@
-.addr   jun-checker                     610000
-.addr   jun-checker-y                   6100a0
-.addr   jun-check-are-same-team         6105e0
-.addr   jun-check-entity-living         610600
-.addr   jun-set-target-allies           610780
-.addr   jun-rng1                        610820
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-checker-y                   {{jun-global-checker-y}}
+.addr   jun-check-are-same-team         {{jun-global-check-are-same-team}}
+.addr   jun-check-entity-living         {{jun-global-check-entity-living}}
+.addr   jun-set-target-allies           {{jun-global-set-target-allies}}
+.addr   jun-rng1                        {{jun-global-rng1}}
+.addr   jun-count-bits                  {{jun-global-count-bits}}
 
 .addr   main-target-manipulation        620200
+.addr   main-target-manip-spread-single 6204e0
 .addr   main-taunt                      620260
-.addr   main-camouflage                 6202b0
+.addr   main-camouflage                 622800
 .addr   main-sneeze-guard               620dc0
 .addr   salve-target-group              620500
 .addr   salve-check-item-is-consumable  620530
@@ -21,19 +23,31 @@
 .addr   menu-active-character           7e62ca
 .addr   selector-targeting-address      7e7a84
 
-.def    jun-index-taunt-full    02
-.def    jun-index-taunt-half    03
-.def    jun-index-salve         07
-.def    jun-index-sneeze-guard  37
-.def    jun-index-camouflage    76
-
 018925: 22 $salve-target-group
 :       ea ea
+
+0258af: 5c $main-target-manip-spread-single
 
 0258ed: 5c $main-target-manipulation
 
 025930: 22 $main-sneeze-guard
 :       ea
+
+$main-target-manip-spread-single
+:       da
+:       f0 spread-single-yes-manip
+:       c2 20
+:       a5 b8
+:       22 $jun-count-bits
+:       e2 20
+:       e0 02
+:       90 spread-single-yes-manip
+.label spread-single-no-manip
+:       fa
+:       5c f6 58 c2
+.label spread-single-yes-manip
+:       fa
+:       5c ed 58 c2
 
 $main-target-manipulation
 # check for runic animation
@@ -41,12 +55,7 @@ $main-target-manipulation
 :       24 b2
 :       f0 just-return
 
-:       22 $jun-rng1
-:       90 no-taunt
-:       a9 jun-index-taunt-half
-:       20 $main-taunt,2
-.label no-taunt
-:       a9 jun-index-taunt-full
+:       a9 {{jun-index-taunt}}
 :       20 $main-taunt,2
 :       20 $main-camouflage,2
 
@@ -56,7 +65,7 @@ $main-target-manipulation
 :       a5 b6
 :       22 $salve-check-item-is-consumable
 :       f0 just-return
-:       a9 jun-index-salve
+:       a9 {{jun-index-salve}}
 :       22 $jun-checker
 :       d0 return-with-salve
 
@@ -79,7 +88,7 @@ $main-sneeze-guard
 .label sneeze-guard-loop
 :       22 $jun-check-are-same-team
 :       d0 sneeze-guard-loop-skip
-:       a9 jun-index-sneeze-guard
+:       a9 {{jun-index-sneeze-guard}}
 :       22 $jun-checker-y
 :       f0 sneeze-guard-loop-skip
 :       c2 20
@@ -114,6 +123,11 @@ $main-taunt
 .label main-taunt-entity-alive
 :       24 b8
 :       f0 main-taunt-skip
+:       e0 08
+:       b0 taunt-is-monster
+:       22 $jun-rng1
+:       b0 main-taunt-unset
+.label taunt-is-monster
 :       a3 05
 :       22 $jun-checker
 :       d0 main-taunt-skip
@@ -124,14 +138,24 @@ $main-taunt
 :       ca ca
 :       10 main-taunt-loop
 
+:       a3 04
+:       aa
 :       a5 b8
 :       f0 main-taunt-fail
-:       68
-:       80 main-taunt-exit
+:       e0 08
+:       b0 main-taunt-pull-exit
+
+:       a3 01
+:       25 b8
+:       d0 main-taunt-fail
+:       80 main-taunt-pull-exit
 
 .label main-taunt-fail
 :       68
 :       85 b8
+:       80 main-taunt-exit
+.label main-taunt-pull-exit
+:       68
 .label main-taunt-exit
 :       28 fa 68
 :       60
@@ -155,7 +179,7 @@ $main-camouflage
 .label main-camouflage-entity-alive
 :       24 b8
 :       f0 main-camouflage-skip
-:       a9 jun-index-camouflage 00
+:       a9 {{jun-index-camouflage}} 00
 :       22 $jun-checker
 :       f0 main-camouflage-skip
 :       bd 18 30
@@ -188,7 +212,7 @@ $salve-target-group
 :       0a
 :       da
 :       aa
-:       a9 jun-index-salve
+:       a9 {{jun-index-salve}}
 :       22 $jun-checker
 :       f0 salve-target-group-return-pull
 :       fa
@@ -233,6 +257,9 @@ VALIDATION
 
 018925: bd 88 26
 :       8d $selector-targeting-address,2
+
+0258af: f0 3c
+:       80 43
 
 0258ed: c2 20
 :       a5 b8

--- a/BeyondChaos/tables/patch_junction_time_font_sink.txt
+++ b/BeyondChaos/tables/patch_junction_time_font_sink.txt
@@ -1,11 +1,8 @@
-.addr   jun-checker                     610000
-.addr   jun-check-count-all-living      610680
-.addr   jun-force-update                610fe0
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-check-count-all-living      {{jun-global-check-count-all-living}}
+.addr   jun-force-update                {{jun-global-force-update}}
 .addr   main                            622000
 .addr   main-initialize                 6220a0
-
-.def    jun-index-time-font     8b
-.def    jun-index-time-sink     8c
 
 0209e4: 22 $main
 
@@ -20,10 +17,10 @@ $main
 :       0a 0a 0a 0a 0a
 
 :       48
-:       a9 jun-index-time-sink 00
+:       a9 {{jun-index-time-sink}} 00
 :       22 $jun-check-count-all-living
 :       48
-:       a9 jun-index-time-font 00
+:       a9 {{jun-index-time-font}} 00
 :       22 $jun-check-count-all-living
 :       38
 :       e3 01

--- a/BeyondChaos/tables/patch_junction_unlimited.txt
+++ b/BeyondChaos/tables/patch_junction_unlimited.txt
@@ -1,10 +1,11 @@
-.addr   jun-checker                     610000
-.addr   jun-rng2                        610830
+.addr   jun-checker                     {{jun-global-checker}}
+.addr   jun-rng2                        {{jun-global-rng2}}
 .addr   main                            621400
 
 .addr   old-rng2                        024b5a
 
-.def    jun-index           7a
+.def    first-desperation-rate          80
+.def    second-desperation-rate         40
 
 0215e9: 22 $main
 :       ea
@@ -12,19 +13,21 @@
 $main
 :       da
 :       bb
-:       a9 jun-index
+:       a9 {{jun-index-unlimited}}
 :       22 $jun-checker
 :       f0 no-junction
 :       b9 18 30
 :       2c 2f 3f
 :       d0 desperation-repeat
 :       22 $jun-rng2
-:       29 01
+:       c9 first-desperation-rate
+:       b0 exit
+:       a9 00
 :       80 exit
 .label desperation-repeat
 :       22 $jun-rng2
-:       29 03
-:       d0 exit
+:       c9 second-desperation-rate
+:       b0 exit
 :       b9 18 30
 :       1c 2f 3f
 :       a9 00

--- a/BeyondChaos/tables/patch_junction_victory_cry.txt
+++ b/BeyondChaos/tables/patch_junction_victory_cry.txt
@@ -1,7 +1,5 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            6210a0
-
-.def    jun-index-victory-cry       73
 
 026236: 22 $main
 :       ea
@@ -11,7 +9,7 @@ $main
 :       da
 :       bb
 
-:       a9 jun-index-victory-cry 00
+:       a9 {{jun-index-victory-cry}} 00
 :       22 $jun-checker
 :       f0 no-victory-cry
 :       bd e4 3e

--- a/BeyondChaos/tables/patch_junction_vip.txt
+++ b/BeyondChaos/tables/patch_junction_vip.txt
@@ -1,25 +1,29 @@
-.addr   jun-checker                     610000
+.addr   jun-checker                     {{jun-global-checker}}
 .addr   main                            6215c0
+
 # BCCE moves this code
-#.addr   banon_check                     0206db
+#.addr   banon_check                     0206d8
 #.addr   return-vip-fell                 0206df
 #.addr   return-normal                   0206e4
-.addr   banon_check                     0206f6
+.addr   banon_check                     0206f3
 .addr   return-vip-fell                 0206fa
 .addr   return-normal                   020700
 
-.def    jun-index-vip       97
-.def    jun-index-highwind  8a
-
 $banon_check
 :       5c $main
+:       ea ea ea
 
 $main
+:       bd f9 3e
+:       89 04
+:       d0 main-exit-normal
+:       bd d8 3e
 :       c9 0e
 :       f0 vip-fell
-:       a9 jun-index-vip
+:       a9 {{jun-index-vip}}
 :       22 $jun-checker
 :       d0 vip-fell
+.label main-exit-normal
 :       5c $return-normal
 .label vip-fell
 :       5c $return-vip-fell
@@ -27,5 +31,14 @@ $main
 VALIDATION
 
 $banon_check
+:       bd d8 3e
 :       c9 0e
 :       d0
+
+$return-vip-fell
+:       a9 06
+:       8d 6e 3a
+
+$return-normal
+:       ca ca
+:       10 99


### PR DESCRIPTION
- Added `jejentojori` code to make `mementomori` innate relics retain junction effects.
- L/R scrolling in the Lore field menu no longer makes lores disappear.
- Randomizer no longer crashes on guest party member junction sanity check.

```
Update `bcg_junction` to abyssonym/beyondchaos_gaiden@dc7c8142

BUGFIXES:
- Final Ripple can no longer trigger multiple times per encounter for enemies.
- Nihopalaoa no longer deals fractional damage or bypasses immunity against death immune targets.
- Auto Potion no longer triggers off of damage over time.
- VIP won't trigger if the unit has reraise.
- Caller junction now observes Gold Hairpin and Economizer.
- MP Switch now properly shows colored numerals for MP damage.

REBALANCES:
- Quickening nerfed, particularly for castings that hit the MP cost cap.
- Reflect boost now applies if either the caster or the reflect target has the junction.
- Enemies with "summon" junctions will summon a random esper.
- Meatbone Cut now functions more like FFT's Meatbone Slash.
- Gold mage now costs 32x MP cost instead of 16x.

NEW JUNCTIONS (6):
- Junction Jam
- Luck Font/Sink
- Juggernaut
- Burst
- Life Force

Furthermore, the junction manager, junction core, and junction effect patches were updated to make them more readable and maintainable (they use templating and named parameters more).
```