### PR TITLE
Multiple custom characters for items at 12 length

### DIFF
--- a/BeyondChaos/itemrandomizer.py
+++ b/BeyondChaos/itemrandomizer.py
@@ -37,6 +37,9 @@ itemdict = {}
 customs = {}
 changed_commands = []
 
+# mutated_names keeps track of which item's names have been mutated and how many times they have been mutated
+mutated_names = {}
+
 break_unused_dict = {0x09: list(range(0xA3, 0xAB)),
                      0x08: list(range(0xAB, 0xB0)) + list(range(0x41, 0x44))}
 
@@ -804,11 +807,24 @@ class ItemBlock:
             self.mutate_break_effect(unbreakable=unbreakable)
 
     def mutate_name(self, vanilla=False, character='?'):
+        global mutated_names
         if vanilla:
             self.name = self.vanilla_data.name
             self.dataname[1:] = name_to_bytes(self.name, len(self.name))
-        elif options.Options_.is_flag_active("questionablecontent") and not self.is_consumable and character not in self.name:
-            self.name = self.name[:11] + character
+            if self.vanilla_data.name in mutated_names.keys():
+                mutated_names[self.vanilla_data.name] = 0
+        elif (options.Options_.is_flag_active("questionablecontent") and not self.is_consumable
+              and character not in self.name):
+            if self.vanilla_data.name not in mutated_names.keys():
+                mutated_names[self.vanilla_data.name] = 0
+            if len(self.name) == 12:
+                # Item name length is at max. Replace the rightmost vanilla character with the custom character.
+                self.name = (self.name[:11 - mutated_names[self.vanilla_data.name]] + character +
+                             self.name[len(self.name) - mutated_names[self.vanilla_data.name]:])
+            else:
+                # Item length is not at max. Add the character to the end.
+                self.name = self.name + character
+            mutated_names[self.vanilla_data.name] = mutated_names[self.vanilla_data.name] + 1
             # Index on self.dataname is [1:] because the first character determines the
             #   equipment symbol (helmet/shield/etc).
             if isinstance(self.dataname, bytes):


### PR DESCRIPTION
- Items with the maximum length of 12 can now have multiple symbols added to them. Symbols are written from right to left, replacing the rightmost vanilla character. For items under 12 length, the symbol is appended to the end as before.