### PR TITLE
SOS Runic and SOS GP Rain Randomized Names

### DIFF
--- a/BeyondChaos/bcg_junction.py
+++ b/BeyondChaos/bcg_junction.py
@@ -67,7 +67,7 @@ def recursive_merge(original, update):
 class JunctionManager:
     MAX_LINE_LENGTH = 32
 
-    def __init__(self, outfile, manifest=None, data=None, update=None):
+    def __init__(self, outfile, manifest=None, data=None, update=None, commands=None):
         self.outfile = get_open_file(outfile)
         self.directory = tblpath
         self.patches = set()
@@ -136,6 +136,13 @@ class JunctionManager:
                     k = self.get_junction_index(k)
                     assert k not in new_dict
                     new_dict[k] = v
+                    if key == 'junction_short_names' and commands:
+                        if v.lower() == "sos gp rain":
+                            print("SOS GP Rain being changed to " + str("SOS " + commands["gprain"].name))
+                            new_dict[k] = "SOS " + commands["gprain"].name
+                        if v.lower() == "sos runic":
+                            print("SOS Runic being changed to " + str("SOS " + commands["runic"].name))
+                            new_dict[k] = "SOS " + commands["runic"].name
                 value = new_dict
                 full_data[key] = value
 

--- a/BeyondChaos/randomizer.py
+++ b/BeyondChaos/randomizer.py
@@ -6089,7 +6089,7 @@ def randomize(connection: Pipe = None, **kwargs) -> str | None:
         if Options_.is_flag_active('thescenarionottaken'):
             chocobo_merchant()
 
-        jm = JunctionManager(outfile_rom_buffer, 'bcg_junction_manifest.json')
+        jm = JunctionManager(outfile_rom_buffer, 'bcg_junction_manifest.json', commands=commands)
         jm.activated = False
         junction_everything(jm)
 


### PR DESCRIPTION
- The list of randomized commands is now passed into bcg_junction and used to change the name of SOS Runic and SOS GP Rain to match any new command names that Runic and GP Rain are randomized into.