### PR TITLE
Updater Testing Update Pt.3

### DIFF
--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -1456,8 +1456,8 @@ if __name__ == '__main__':
                     missing_required_files = update.validate_required_files()
 
             available_updates = update.list_available_updates(refresh=True)
-            skip_updates = config.get('Settings', 'updates_hidden', fallback=False)
-            if not skip_updates and available_updates:
+            skip_updates = config.get('Settings', 'updates_hidden', fallback='False')
+            if available_updates and skip_updates.lower() == 'false':
                 while available_updates:
                     update_message = QMessageBox()
                     update_message.setIcon(QMessageBox.Question)
@@ -1486,6 +1486,7 @@ if __name__ == '__main__':
                         if button_clicked == QMessageBox.Close:
                             update_dismiss_message.close()
                             set_config_value('Settings', 'updates_hidden', str(True))
+                            break
                     elif button_clicked == QMessageBox.Ok:
                         update_bc(suppress_prompt=True, calling_program=App)
                         available_updates = update.list_available_updates(refresh=True)


### PR DESCRIPTION
beyondchaos.py:
- Added a break statement in the Available Updates prompt. People who decline will no longer be stuck in an infinite loop until they agree to update.
- The Updates Available prompt now shows properly, instead of never.

update.py:
- Remonsterate files are now always created if they are missing, instead of just when remonsterate updates.
- The update_remonsterate() method now has a 'force' flag that forcibly regenerates the text files in the directory.
- The updater now restarts Beyond Chaos whenever any update is performed, because the randomizer needs to reload to enable spritereplacements, remonsterate, etc.