### PR TITLE
Junction fixes 2024-05-24

### DIFF
--- a/BeyondChaos/tables/bcg_junction_manifest.json
+++ b/BeyondChaos/tables/bcg_junction_manifest.json
@@ -979,7 +979,8 @@
             "patch_junction_critical_trigger.txt"
         ],
         "critical_quick":  [
-            "patch_junction_critical_trigger.txt"
+            "patch_junction_critical_trigger.txt",
+            "patch_instant_enemy_quick.txt"
         ],
         "critical_cure3":  [
             "patch_junction_critical_trigger.txt"

--- a/BeyondChaos/tables/patch_instant_enemy_quick.txt
+++ b/BeyondChaos/tables/patch_instant_enemy_quick.txt
@@ -1,0 +1,19 @@
+.addr   main-atb                        57f0e0
+
+0211bb: 22 $main-atb
+:       ea
+
+$main-atb:
+:       ec 04 34
+:       d0 not-quick
+:       a9 ff
+:       9d 19 32
+.label not-quick
+:       c2 21
+:       bd 18 32
+:       6b
+
+VALIDATION
+
+0211bb: c2 21
+:       bd 18 32

--- a/BeyondChaos/tables/patch_junction_cover.txt
+++ b/BeyondChaos/tables/patch_junction_cover.txt
@@ -5,12 +5,10 @@
 .addr   jun-bit-to-index                {{jun-global-bit-to-index}}
 
 .addr   main                            621e00
-.addr   check-paladins                  621ea0
-.addr   check-popular                   621ee0
-.addr   get-potential-bodyguards        621e40
 .addr   return-love-token               021259
 .addr   return-no-bodyguards            02125f
 .addr   wide-bits                       00b4f3
+.addr   acting-as-enemies               7e3a42
 
 021254: 5c $main
 
@@ -20,21 +18,21 @@ $main
 .label exit-with-bodyguard
 :       5c $return-love-token
 .label check-junctions
-:       20 $check-paladins,2
+:       20 @check-paladins,2
 :       10 exit-with-bodyguard
 .label no-paladins
 :       bb
 :       a9 {{jun-index-popular}} 00
 :       22 $jun-checker
 :       f0 no-bodyguards
-:       20 $check-popular,2
+:       20 @check-popular,2
 :       10 exit-with-bodyguard
 .label no-bodyguards
 :       a2 ff
 :       5c $return-no-bodyguards
 
-$check-paladins
-:       20 $get-potential-bodyguards,2
+.label check-paladins
+:       20 @get-potential-bodyguards,2
 :       a2 12
 
 .label paladins-loop
@@ -63,8 +61,8 @@ $check-paladins
 :       a2 ff
 :       60
 
-$check-popular
-:       20 $get-potential-bodyguards,2
+.label check-popular
+:       20 @get-potential-bodyguards,2
 :       c9 00 00
 :       f0 popular-fail
 :       22 $jun-select-bit
@@ -75,7 +73,7 @@ $check-popular
 :       a2 ff
 :       60
 
-$get-potential-bodyguards
+.label get-potential-bodyguards
 :       a9 00 00
 :       a2 12
 :       48
@@ -114,11 +112,18 @@ $get-potential-bodyguards
 :       d0 potential-pull-exit
 :       68
 .label potential-force-allies-only
+:       48
 :       c0 08
 :       b0 potential-is-monster
+:       bb
+:       bf $wide-bits
+:       2d $acting-as-enemies,2
+:       d0 potential-is-monster
+:       68
 :       29 0f 00
 :       60
 .label potential-is-monster
+:       68
 :       29 f0 ff
 :       60
 .label potential-pull-exit

--- a/BeyondChaos/tables/patch_junction_critical_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_critical_trigger.txt
@@ -76,12 +76,6 @@ $main
 :       22 $jun-checker
 :       f0 skip-spell
 :       20 $do-self-spell,2
-:       c9 {{jun-index-critical-quick}}
-:       d0 skip-spell
-:       48
-:       a9 00
-:       9d 19 32
-:       68
 .label skip-spell
 :       1a
 :       c9 overflow-spell-index

--- a/BeyondChaos/tables/patch_junction_damage_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_damage_trigger.txt
@@ -22,7 +22,7 @@
 .addr   check-nihopalaoa                622940
 .addr   check-heal                      6217a0
 .addr   check-brace                     621280
-.addr   check-catch                     6212a0
+.addr   check-catch                     620c80
 .addr   boost-healing-half              620ea0
 .addr   boost-healing-double            620ec0
 .addr   boost-damage-double             620ee0
@@ -472,6 +472,11 @@ $check-catch
 :       9e d0 33
 :       e0 08
 :       b0 catch-exit
+
+:       ad 7a 3a
+:       29 ff 00
+:       c9 throw-index 00
+:       d0 catch-exit
 
 :       22 $jun-rng1
 :       b0 catch-exit

--- a/BeyondChaos/tables/patch_junction_freebie.txt
+++ b/BeyondChaos/tables/patch_junction_freebie.txt
@@ -10,9 +10,13 @@
 
 $main
 :       08
-:       ad 7c 3a
-:       c9 09
-:       f0 exit-no-freebie
+:       ad 7a 3a
+:       c9 01
+:       f0 freebie-valid-command
+:       c9 08
+:       f0 freebie-valid-command
+:       80 exit-no-freebie
+.label freebie-valid-command
 :       22 $jun-rng2
 :       c9 freebie-rate
 :       b0 exit-no-freebie

--- a/BeyondChaos/tables/patch_junction_hit_trigger.txt
+++ b/BeyondChaos/tables/patch_junction_hit_trigger.txt
@@ -4,10 +4,12 @@
 .addr   jun-rng1                        {{jun-global-rng1}}
 .addr   jun-queue-command               {{jun-global-queue-command}}
 .addr   jun-check-is-damage-over-time   {{jun-global-check-is-damage-over-time}}
-.addr   main                            622400
+.addr   jun-check-are-same-team         {{jun-global-check-are-same-team}}
+.addr   main                            622e00
 .addr   null-secondary-data             6227e0
 .addr   do-quickening-penalty           622780
 
+.addr   stolen-item                     7e32f4
 .addr   living-characters               7e3a74
 .addr   current-level-address           7e3b18
 .addr   current-current-hp-address      7e3bf4
@@ -24,14 +26,22 @@
 
 0231b6: 22 $main
 
+0239a1: 5c @main-steal,3
+:       ea
+.label return-steal
+:       e0 08
+:       b0 5f
+
+0239fd: ee 01 34
+.label return-no-steal
+023a00: 60
+
 $main
 :       22 $jun-check-is-damage-over-time
 :       f0 not-damage-over-time
 :       82 no-junction,2
 
 .label not-damage-over-time
-:       a5 b8
-:       d0 no-add-steal
 :       ad a9 11
 :       d0 no-add-steal
 :       22 $jun-rng1
@@ -146,6 +156,21 @@ $main
 :       14 b2
 :       6b
 
+.label main-steal
+:       22 $jun-check-are-same-team
+:       d0 main-return-no-steal
+:       e0 08
+:       b0 main-return-steal
+:       bd $stolen-item,2
+:       1a
+:       d0 main-return-no-steal
+:       a9 01
+:       8d 01 34
+.label main-return-steal
+:       5c @return-steal,3
+.label main-return-no-steal
+:       5c @return-no-steal,3
+
 $do-quickening-penalty
 :       5a
 
@@ -213,3 +238,11 @@ VALIDATION
 
 0231b6: a9 20
 :       14 b2
+
+0239a1: a9 01
+:       8d 01 34
+:       e0 08
+:       b0 5f
+
+0239fd: ee 01 34
+023a00: 60


### PR DESCRIPTION
This fixes various junction bugs

- Fixed the bug where enemies with SOS Quick would crash the game. A side effect of this fix is that an enemy under the Quick effect will charge their ATB instantaneously, taking their turns immediately.
- Party members acting as enemies (i.e. Kefka at the imperial base, Shadow at the colosseum) will no longer benefit from the party's True Paladin junction.
- Fixed item duplication exploits associated with combining the Catch/Freebie junctions with Mimic or a throwable weapon like Hawk Eye. Freebie only triggers off of Throw or Item commands, and not Mimic. Catch will still block throwable Hawk Eye, but will only add the item to the inventory if it was thrown with a Throw command.
- Enemies can now use the Add Steal junction. Fixed various issues related to stealing from multiple targets and stealing from allies. As a side effect of this, the issue related to stealing multiple times with Offering or Genji Glove may be fixed; all attempts to steal after the first successful steal are ignored.