### PR TITLE
Added Dark Mode

### DIFF
--- a/BeyondChaos/beyondchaos.py
+++ b/BeyondChaos/beyondchaos.py
@@ -44,16 +44,22 @@ control_fixed_width = 70
 control_fixed_height = 20
 spacer_fixed_height = 5
 current_theme = config.get('Settings', 'gui_theme', fallback='Light')
+
+# Light mode themes, for items that cannot be styled with the css file due to PyQt limitations
 inactive_flag_light_theme_stylesheet = 'background-color: white; border: none; color: black;'
 active_flag_light_theme_stylesheet = 'background-color: #CCE4F7; border: 1px solid darkblue; color: black;'
 disabled_flag_light_theme_stylesheet = 'background-color: #fedada; border: none; color: black;'
+hyperlink_light_theme_stylesheet = 'color: #0d7eb9;'
+
+# Other mode themes, for items that cannot be styled with the css file due to PyQt limitations
 inactive_flag_other_theme_stylesheet = 'background-color: #232629; border: none; color: white;'
 active_flag_other_theme_stylesheet = 'background-color: #010030; border: 1px solid #A1A0D0; color: white;'
 disabled_flag_other_theme_stylesheet = 'background-color: #390000; border: none; color: white;'
+hyperlink_other_theme_stylesheet = 'color: #5dcef9;'
 
 
 class QDialogScroll(QDialog):
-    def __init__(self, title: str = '', header: str = '', scroll_contents: QWidget = None,
+    def __init__(self, scroll_contents: QWidget, title: str = '', header: str = '',
                  left_button: str = '', right_button: str = '', icon=None):
         super().__init__()
         self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
@@ -72,15 +78,14 @@ class QDialogScroll(QDialog):
         header_text = QLabel(header)
         header_text.setOpenExternalLinks(True)
 
-        flag_list_label = scroll_contents
-        flag_list_scroll = QScrollArea(self)
-        flag_list_scroll.setMinimumWidth(self.minimumWidth() - 100)
-        flag_list_scroll.setEnabled(True)
-        flag_list_scroll.setWidgetResizable(True)
-        flag_list_scroll.setWidget(flag_list_label)
+        scroll_area = QScrollArea(self)
+        scroll_area.setMinimumWidth(self.minimumWidth() - 100)
+        scroll_area.setEnabled(True)
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setWidget(scroll_contents)
 
         grid_layout.addWidget(header_text, 1, 0, 1, 9)
-        grid_layout.addWidget(flag_list_scroll, 2, 0, 1, 9)
+        grid_layout.addWidget(scroll_area, 2, 0, 1, 9)
 
         self.left_pushbutton = None
         self.right_pushbutton = None
@@ -1552,6 +1557,10 @@ class Window(QMainWindow):
                         )
                         gen_traceback.setProperty('class', 'traceback')
                         gen_traceback.setReadOnly(True)
+                        if current_theme == 'Light':
+                            hyperlink_style = hyperlink_light_theme_stylesheet
+                        else:
+                            hyperlink_style = hyperlink_other_theme_stylesheet
                         QDialogScroll(
                             title=f'Exception: {str(type(gen_exception).__name__)}',
                             header=f'A {str(type(gen_exception).__name__)} ' +
@@ -1560,7 +1569,8 @@ class Window(QMainWindow):
                                    '<br>' +
                                    '<br>' +
                                    'Please submit the following traceback over at the '
-                                   '<a href="https://discord.gg/ZCHZp7qxws">Beyond Chaos Barracks discord</a> '
+                                   f'<a style="{hyperlink_style}" ' +
+                                   'href="https://discord.gg/ZCHZp7qxws">Beyond Chaos Barracks discord</a> '
                                    'bugs channel:' +
                                    '<br>',
                             scroll_contents=gen_traceback,

--- a/BeyondChaos/custom/gui_themes/darkmode.css
+++ b/BeyondChaos/custom/gui_themes/darkmode.css
@@ -210,29 +210,29 @@ QPushButton:hover
     color: #eff0f1;
 }
 QPushButton[class="clear_ui"]{
-    font-size:12px; 
-    height:60px
-}
-QPushButton[class="generate_button"]{
-    font:bold;
-    font-size:18px;
-    height:24px;
-    background-color:#010030;
-    color:#E4E4E4;
+    font-size: 12px;
+    height: 60px
 }
 QPushButton[class="rom_file_picker"]{
-    font:bold;
+    font: bold;
     font-size:18px;
     height:24px;
     background-color: #010030;
     color:#E4E4E4;
 }
 QPushButton[class="rom_output_picker"]{
-    font:bold;
-    font-size:18px;
-    height:24px;
+    font: bold;
+    font-size: 18px;
+    height: 24px;
     background-color: #010030;
-    color:#E4E4E4;
+    color: #E4E4E4;
+}
+QPushButton[class="generate_button"]{
+    font: bold;
+    font-size: 18px;
+    height: 24px;
+    background-color: #010030;
+    color: #E4E4E4;
 }
 /*
 						Combo Boxes

--- a/BeyondChaos/custom/gui_themes/darkmode.css
+++ b/BeyondChaos/custom/gui_themes/darkmode.css
@@ -1,0 +1,336 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) <2024-2025> <BeyondChaosRandomizer>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+						Parent Layout Classes
+*/
+QMainWindow::separator
+{
+    background-color: #31363b;
+    color: white;
+    border-color: #76797C;
+}
+QMainWindow::separator:hover
+{
+
+    background-color: #787876;
+    color: white;
+    border-color: #76797C;
+}
+QWidget
+{
+    color: #eff0f1;
+    background-color: #31363b;
+    selection-background-color:#3daee9;
+    selection-color: #eff0f1;
+    border-color: white;
+}
+QWidget:item:hover
+{
+    background-color: #18465d;
+    color: #eff0f1;
+}
+QWidget:disabled
+{
+    color: #454545;
+    background-color: #31363b;
+    color: white;
+}
+QWidget:focus
+{
+    border-color: #3daee9;
+}
+QFrame
+{
+    border-color: #76797C;
+}
+QFrame[class="flag_v_spacer"]
+{
+    margin: 5px 0 0 0;
+}
+QFrame[class="flag_h_spacer"]
+{
+    margin: 0 2px 0 2px;
+}
+QFrame[class="flag_h_spacer_final"]
+{
+    display:none;
+}
+/*
+						Menu Bar
+*/
+QMenu
+{
+    background-color: #31363b;
+    border-color: #76797C;
+    color: #eff0f1;
+}
+QMenu::item
+{
+    border-color: transparent;
+}
+QMenu::item:selected
+{
+    color: #eff0f1;
+}
+QMenu::separator
+{
+    background-color: #76797C;
+    color: white;
+}
+QMenuBar:focus
+{
+    border-color: #3daee9;
+}
+/*
+						Tooltips
+*/
+QToolTip
+{
+    border-color: #76797C;
+    background-color: rgb(90, 102, 117);
+    color: white;
+    opacity: 200;
+}
+/*
+						Group Box
+*/
+QGroupBox 
+{
+    border-color:#76797C;
+}
+/*
+						Tabs
+*/
+QTabWidget{
+    border-color: black;
+}
+QTabWidget:focus
+{
+
+}
+QTabWidget::pane
+{
+    border-color: #76797C;
+}
+QTabBar::tab
+{
+    color: white;
+}
+QTabBar::tab:selected
+{
+}
+/*
+						Labels
+*/
+QLabel
+{
+    border-color: black;
+}
+QLabel[class="flag_message"]
+{
+    margin-left: 2px;
+}
+QLabel[class="game_mode_label"]
+{
+    padding-left: 22px;
+}
+QLabel[class="preset_label"]
+{
+    padding-left: 22px;
+}
+QLabel[class="preset_description"]
+{
+    font-size: 14px;
+    height: 24px;
+    color: white;
+    padding-left: 22px;
+}
+QLabel[class="current_preset"]
+{
+    font-size: 14px;
+    height: 24px;
+    color: white;
+}
+QLabel[class="error"]
+{
+    color: #fedada;
+}
+/*
+						Buttons
+*/
+QPushButton
+{
+    color: #eff0f1;
+    background-color: #31363b;
+    border-color: #76797C;
+}
+QPushButton:disabled
+{
+    background-color: #31363b;
+    border-color: #454545;
+    color: #454545;
+}
+QPushButton:focus {
+    background-color: #3daee9;
+    color: white;
+}
+QPushButton:pressed
+{
+    background-color: #3daee9;
+}
+QPushButton:checked{
+    background-color: #76797C;
+    border-color: #6A6969;
+}
+QPushButton:hover
+{
+    border-color: #3daee9;
+    color: #eff0f1;
+}
+QPushButton[class="clear_ui"]{
+    font-size:12px; 
+    height:60px
+}
+QPushButton[class="generate_button"]{
+    font:bold;
+    font-size:18px;
+    height:24px;
+    background-color:#010030;
+    color:#E4E4E4;
+}
+QPushButton[class="rom_file_picker"]{
+    font:bold;
+    font-size:18px;
+    height:24px;
+    background-color: #010030;
+    color:#E4E4E4;
+}
+QPushButton[class="rom_output_picker"]{
+    font:bold;
+    font-size:18px;
+    height:24px;
+    background-color: #010030;
+    color:#E4E4E4;
+}
+/*
+						Combo Boxes
+*/
+QComboBox
+{
+    selection-background-color: #3daee9;
+    border-color: #76797C;
+    background-color: #232629;
+}
+QComboBox:hover{
+    border-color: #3daee9;
+    color: #eff0f1;
+}
+QComboBox:on
+{
+    selection-background-color: #4a4a4a;
+}
+QComboBox QAbstractItemView
+{
+    selection-color: black;
+}
+/*
+						Single-line Text Boxes
+*/
+QLineEdit
+{
+    background-color: #232629;
+    border: 1px solid darkgrey;
+    color: #eff0f1;
+}
+QLineEdit:hover
+{
+    border-color: #3daee9;
+    color: #eff0f1;
+}
+/*
+						Multi-line Text Boxes
+*/
+QTextEdit
+{
+    background-color: #232629;
+    color: #eff0f1;
+    border-color: #76797C;
+}
+QTextEdit[class="traceback"]{
+    background-color: rgba(0,0,0,0); 
+    border: none;
+}
+QTextEdit:hover
+{
+    border-color: #3daee9;
+    color: #eff0f1;
+}
+/*
+						Checkboxes
+*/
+QCheckBox
+{
+    color: #eff0f1;
+}
+QCheckBox:disabled
+{
+    color: #76797C;
+}
+
+/*
+						Number Boxes
+*/
+QSpinBox::up-button
+{
+     width: 20px;
+}
+QSpinBox::down-button
+{
+     width: 20px;
+}
+QSpinBox[class="batch_count"]
+{
+    border: 1px solid darkgrey;
+    background-color: #232629;
+    color: #eff0f1;    
+    border-radius: 2px;
+    height: 20px;
+}
+QSpinBox[class="batch_count"]::up-button
+{
+     width: 20px;
+}
+QSpinBox[class="batch_count"]::down-button
+{
+     width: 20px;
+}
+QDoubleSpinBox::up-button
+{
+     width: 20px;
+}
+QDoubleSpinBox::down-button
+{
+     width: 20px;
+}

--- a/BeyondChaos/custom/gui_themes/lightmode.css
+++ b/BeyondChaos/custom/gui_themes/lightmode.css
@@ -1,0 +1,148 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) <2024-2025> <BeyondChaosRandomizer>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+						Parent Layout Classes
+*/
+QFrame[class="flag_v_spacer"]{
+    margin: 5px 0 0 0;
+}
+QFrame[class="flag_h_spacer"]{
+    margin: 0 2px 0 2px;
+}
+QFrame[class="flag_h_spacer_final"]{
+    display:none;
+}
+/*
+						Labels
+*/
+QLabel[class="flag_message"]{
+    margin-left: 2px;
+}
+QLabel[class="game_mode_label"]{
+    padding-left: 22px;
+}
+QLabel[class="preset_label"]{
+    padding-left: 22px;
+}
+QLabel[class="preset_description"]{
+    font-size: 14px;
+    height: 24px;
+    color: #253340;
+    padding-left: 22px;
+}
+QLabel[class="current_preset"]{
+    font-size: 14px;
+    height: 24px;
+    color: #253340;
+}
+QLabel[class="error"]{
+    color: darkred;
+}
+/*
+						Buttons
+*/
+QPushButton[class="clear_ui"]{
+    font-size:12px; 
+    height:60px
+}
+QPushButton[class="generate_button"]{
+    font:bold;
+    font-size:18px;
+    height:24px;
+    background-color:#5A8DBE;
+    color:#E4E4E4;
+}
+QPushButton[class="rom_file_picker"]{
+    font:bold;
+    font-size:18px;
+    height:24px;
+    background-color: #5A8DBE;
+    color:#E4E4E4;
+}
+QPushButton[class="rom_output_picker"]{
+    font:bold;
+    font-size:18px;
+    height:24px;
+    background-color: #5A8DBE;
+    color:#E4E4E4;
+}
+/*
+						Combo Boxes
+*/
+QComboBox
+{
+    selection-background-color: #3daee9;
+}
+QComboBox:hover{
+    border-color: #3daee9;
+    color: #eff0f1;
+}
+QComboBox QAbstractItemView
+{
+    selection-color: black;
+}
+/*
+						Single-line Text Boxes
+*/
+QTextEdit[class="traceback"]{
+    background-color: rgba(0,0,0,0); 
+    border: none;
+}
+/*
+						Multi-line Text Boxes
+*/
+/*
+						Number Boxes
+*/
+QSpinBox::up-button
+{
+     width: 20px;
+}
+QSpinBox::down-button
+{
+     width: 20px;
+}
+QSpinBox[class="batch_count"]
+{
+    border: 1px solid lightgrey;
+    border-radius: 2px;
+    height: 20px;
+}
+QSpinBox[class="batch_count"]::up-button
+{
+     width: 20px;
+}
+QSpinBox[class="batch_count"]::down-button
+{
+     width: 20px;
+}
+QDoubleSpinBox::up-button
+{
+     width: 20px;
+}
+QDoubleSpinBox::down-button
+{
+     width: 20px;
+}

--- a/BeyondChaos/custom/gui_themes/lightmode.css
+++ b/BeyondChaos/custom/gui_themes/lightmode.css
@@ -64,29 +64,29 @@ QLabel[class="error"]{
 						Buttons
 */
 QPushButton[class="clear_ui"]{
-    font-size:12px; 
-    height:60px
-}
-QPushButton[class="generate_button"]{
-    font:bold;
-    font-size:18px;
-    height:24px;
-    background-color:#5A8DBE;
-    color:#E4E4E4;
+    font-size: 12px;
+    height: 60px
 }
 QPushButton[class="rom_file_picker"]{
-    font:bold;
-    font-size:18px;
-    height:24px;
+    font: bold;
+    font-size: 18px;
+    height: 24px;
     background-color: #5A8DBE;
-    color:#E4E4E4;
+    color: #E4E4E4;
 }
 QPushButton[class="rom_output_picker"]{
-    font:bold;
-    font-size:18px;
-    height:24px;
+    font: bold;
+    font-size: 18px;
+    height: 24px;
     background-color: #5A8DBE;
-    color:#E4E4E4;
+    color: #E4E4E4;
+}
+QPushButton[class="generate_button"]{
+    font: bold;
+    font-size: 18px;
+    height: 24px;
+    background-color: #5A8DBE;
+    color: #E4E4E4;
 }
 /*
 						Combo Boxes


### PR DESCRIPTION
darkmode.css: Added
lightmode.css: Added

beyondchaos.py:
- Alphabetically ordered QtWidgets imports
- Added several dynamic stylesheets for the widget controls, which cannot be styled using an external css file due to limitations in how PyQt5 works. Styles cannot be dynamically changed by changing a widget property at runtime unless the property is changed and then the whole style sheet is reapplied. In my testing, reapplying the style sheet with each flag button changed or clicked rendered the program too unresponsive.
- Removed most setStyleSheet calls. Those styles were moved into an external .css file. This allows the styles to be customized more easily by the users. The downside is that the GUI looks quite plain if the css files are not present in the custom directory.
- Added class properties to various objects to allow the .css styling to pick and choose specific objects to add styles to.
- Improved many different objects by adding additional styles to the css files. For example, the number box buttons actually have visible arrows, which only appear when the buttons are about 20 pixels in width.
- Cleaned up various commented out code.