### PR TITLE
GUI Game Mode Conflicts and Requirements Support

### DIFF
--- a/BeyondChaos/options.py
+++ b/BeyondChaos/options.py
@@ -9,6 +9,10 @@ class Mode:
     name: str
     display_name: str
     description: str
+
+    # TODO: Change forced_flags and prohibited flags to be in line with Flag.requirements and Flag.conflicts
+    #   At minimum, forced_flags needs to take name:value pairs. This requires an adjustment of existing code.
+    #   Not a high priority as long as forced_flags contains only boolean flags.
     forced_flags: List[str] = field(default_factory=list)
     prohibited_flags: Set[str] = field(default_factory=set)
 
@@ -439,7 +443,9 @@ ANCIENT_CAVE_PROHIBITED_FLAGS = {
     "strangejourney",
     "worringtriad",
     "thescenarionottaken",
-
+    'regionofdoom'
+    'morefanatical',
+    'lessfanatical'
 }
 
 ALL_MODES = [
@@ -452,7 +458,8 @@ ALL_MODES = [
         name="katn",
         display_name='Race - Kefka @ Narshe',
         description="Play the normal story up to Kefka at Narshe. Intended for racing.",
-        prohibited_flags={"d", "k", "r", "airship", "alasdraco", "worringtriad", "mimetime"}
+        prohibited_flags={"d", "k", "r", "airship", "alasdraco", "worringtriad", "mimetime", 'morefanatical',
+                          'lessfanatical', 'regionofdoom', 'fightclub'}
     ),
     Mode(
         name="ancientcave",
@@ -482,7 +489,7 @@ ALL_MODES = [
         display_name='Race - Dragon Hunt',
         description="Kill all 8 dragons in the World of Ruin. Intended for racing.",
         forced_flags=["worringtriad"],
-        prohibited_flags={"j", "airship", "alasdraco", "thescenarionottaken"}
+        prohibited_flags={"j", "airship", "alasdraco", "thescenarionottaken", 'rushforpower', 'shadowstays'}
     ),
 ]
 

--- a/BeyondChaos/wor.py
+++ b/BeyondChaos/wor.py
@@ -484,9 +484,8 @@ def zone_eater_recruit(outfile_rom_buffer: BytesIO, char_id):
     zone_eater_recruit_sub = Substitution()
     zone_eater_recruit_sub.set_location(0xB81CF)
     zone_eater_recruit_sub.bytestring = bytes(prefix + [0x3D, char_id, 0xC0, 0x27, 0x01, 0x00, 0x82, 0x01])
-    zone_eater_recruit_sub.write(outfile_rom_buffer, noverify=True) #noverify is correct as this handles naming Mog
-                                                                    # whether you have met him or not by WoR first meeting
-
+    # noverify is correct as this handles naming Mog whether you have met him or not by WoR first meeting
+    zone_eater_recruit_sub.write(outfile_rom_buffer, noverify=True)
 
 
 def collapsing_house_recruit(unused_fout, unused_char_id):


### PR DESCRIPTION
The GUI will now disable flags that are either conflicting or required with the selected game mode, forcing them on or off.

beyondchaos.py:
- handle_conflicts_and_requirements now processes the forced_flags and prohibited_flags of the selected game mode. Flags that are forced_flags are set active and disabled. Flags that are prohibited_flags are set inactive and disabled.
- handle_conflicts_and_requirements now uses a disabled_value_override variable that determines what value the flag is set to when disabled, instead of always setting value = ''.
- Added a change handler for the game mode selection combo box.

options.py:
- Added some additional prohibited flags to many game mode, such as ones affecting a different world than the game will take place in.