### PR TITLE
Temporary Fix: Tools as Weapons

### DIFF
--- a/BeyondChaos/itemrandomizer.py
+++ b/BeyondChaos/itemrandomizer.py
@@ -166,11 +166,15 @@ class ItemBlock:
 
     @property
     def is_tool(self):
-        return self.itemtype & 0x0f == 0x00
+        return self.itemtype & 0x0f == 0x00 or self.name in ['AutoCrossbow', 'NoiseBlaster', 'Bio Blaster',
+                                                             'Flash', 'Drill', 'Chain Saw', 'Air Anchor',
+                                                             'Debilitator']
 
     @property
     def is_weapon(self):
-        return self.itemtype & 0x0f == 0x01
+        return self.itemtype & 0x0f == 0x01 and self.name not in ['AutoCrossbow', 'NoiseBlaster', 'Bio Blaster',
+                                                                  'Flash', 'Drill', 'Chain Saw', 'Air Anchor',
+                                                                  'Debilitator']
 
     @property
     def is_armor(self):


### PR DESCRIPTION
Recently, Tools were changed to be weapon-type items to allow them to be inspected for mutations. This had unintended effects on weapon and shop randomization. As a workaround, ItemBlock.is_weapon and ItemBlock.is_tool have been adjusted to handle tools differently by item name.