### PR TITLE
Fixed the use of built-in presets in console mode.

### DIFF
--- a/BeyondChaos/config.py
+++ b/BeyondChaos/config.py
@@ -27,7 +27,6 @@ MD5HASHNORMAL = "e986575b98300f721ce27c180264d890"
 MD5HASHTEXTLESS = "f08bf13a6819c421eee33ee29e640a1d"
 MD5HASHTEXTLESS2 = "e0984abc9e5dd99e4bc54e8f9e0ff8d0"
 
-# Supported preset names must be lowercase.
 SUPPORTED_PRESETS = {
     'New Player': 'b c e f g i n o p q r s t w y z alphalores informativemiss '
                   'magicnumbers mpparty nicerpoison questionablecontent regionofdoom relicmyhat '

--- a/BeyondChaos/console.py
+++ b/BeyondChaos/console.py
@@ -331,10 +331,12 @@ def run_console():
                     pass
                 flag_input = flag_input.split('|')[2]
                 active_flags = []
-            if flag_input.lower() in SUPPORTED_PRESETS.keys():
-                flag_input = SUPPORTED_PRESETS[flag_input.lower()]
-                active_flags = []
-            input_flag_list = flag_input.split(' ')
+            for preset_key in SUPPORTED_PRESETS.keys():
+                if flag_input.lower() == preset_key.lower():
+                    flag_input = SUPPORTED_PRESETS[preset_key]
+                    active_flags = []
+                    break
+            input_flag_list = filter(lambda f: f != "", flag_input.split(' '))
             for input_flag in input_flag_list:
                 input_flag_found = False
                 if ':' in input_flag:


### PR DESCRIPTION
The built-in presets having uppercase letters caused it to break when entering those names, because lower() was being called prior to comparing the names.

A comment in config.py said that preset names should always be lowercase, probably because of this problem.  Rather than lowercase the names, I fixed the code to work fine with uppercase preset names, and removed the comment of course.

I fixed another bug in console too: presets with a space at the end of their flag list would cause an error because split(' ') was used and it tried to interpret an empty flag name.  I made the code filter empty flag names, which happens if there are spaces at the beginning or end of a flag list, or there is double spacing between flags.  Now they'll just work as expected, ignoring the superfluous spacing.